### PR TITLE
Added $params property to Request with merged GET, POST, PUT and DELETE ...

### DIFF
--- a/flight/net/Request.php
+++ b/flight/net/Request.php
@@ -109,6 +109,11 @@ class Request {
     public $files;
 
     /**
+     * @var \flight\util\Collection Merged GET, POST, PUT and DELETE parameters
+     */
+    public $params;
+
+    /**
      * @var bool Whether the connection is secure
      */
     public $secure;
@@ -178,6 +183,11 @@ class Request {
 
             $this->query->setData($_GET);
         }
+
+        $raw_params = array();
+        parse_str($this->body, $raw_params);
+
+        $this->params = new Collection(array_merge($this->query->getData(), $this->data->getData(), $raw_params));
     }
 
     /**


### PR DESCRIPTION
...params.

I thought it would be useful to have a single Collection with all the GET, POST and raw (PUT and DELETE from php://input) parameters merged together. This would allow for a layer of abstraction between the method of a request and the mapped function.
