### PR TITLE
Provide content-length header if response has a body

### DIFF
--- a/flight/net/Response.php
+++ b/flight/net/Response.php
@@ -191,7 +191,6 @@ class Response {
             $this->headers['Expires'] = gmdate('D, d M Y H:i:s', $expires) . ' GMT';
             $this->headers['Cache-Control'] = 'max-age='.($expires - time());
         }
-
         return $this;
     }
 
@@ -234,6 +233,11 @@ class Response {
             else {
                 header($field.': '.$value);
             }
+        }
+
+        // Send content length
+        if( ($length = strlen($this->body)) > 0) {
+            header("Content-Length: $length");
         }
 
         return $this;


### PR DESCRIPTION
This change adds a content-length header in case the response has a body. This allows keep-alive/pipelined http connections with php applications using flight.
