### PR TITLE
include pragma='no-cache' in the cache header reset

### DIFF
--- a/flight/net/Response.php
+++ b/flight/net/Response.php
@@ -190,6 +190,9 @@ class Response {
             $expires = is_int($expires) ? $expires : strtotime($expires);
             $this->headers['Expires'] = gmdate('D, d M Y H:i:s', $expires) . ' GMT';
             $this->headers['Cache-Control'] = 'max-age='.($expires - time());
+            if (isset($this->headers['Pragma']) && $this->headers['Pragma'] == 'no-cache'){
+                unset($this->headers['Pragma']);
+            }
         }
         return $this;
     }


### PR DESCRIPTION
Once `\flight\Response::cache` has been called with argument `$expires = false`, it cannot be reset because of the header `"Pragma=no-cache"`.  This change removes that header when `cache` is called with a non-false `$expires`.

Example case: selectively enabling cache for ajax requests.  In `\flight\Engine::_start`, all ajax requests disable the cache (see comment `// Disable caching for AJAX requests`).  Re-enabling cache for a given request is not possible (cleanly), because the pragma header persists.  After this change, an ajax request can re-enable http cache by calling `\flight\Response::cache` with a future time value.
