### PR TITLE
Fixes #169

### DIFF
--- a/flight/net/Route.php
+++ b/flight/net/Route.php
@@ -72,7 +72,7 @@ class Route {
      */
     public function matchUrl($url) {
         // Wildcard or exact match
-        if ($this->pattern === '*' || $this->pattern === $url) {
+        if ($this->pattern === '*' || ($this->pattern === $url && ! strstr($url, '@'))) {
             if ($this->pass) {
                 $this->params[] = $this;
             }


### PR DESCRIPTION
Check that in exact match there is no parameters.
It's just a dummy check for `@` for now, but if you will think it's not OK, can write RegEx.
