### PR TITLE
Update Request.php to make flightphp working even if your documentroot is a subfolder

### DIFF
--- a/flight/net/Request.php
+++ b/flight/net/Request.php
@@ -164,9 +164,7 @@ class Request {
         }
 
         // Get the requested URL without the base directory
-        if ($this->base != '/' && strlen($this->base) > 0 && strpos($this->url, $this->base) === 0) {
-            $this->url = substr($this->url, strlen($this->base));
-        }
+        $this->url = self::getVar('QUERY_STRING');
 
         // Default url
         if (empty($this->url)) {


### PR DESCRIPTION
# Case

I want to set the root directory to the subdirectory `/public` so users can't access config files etc. This didn't work for me with the current FlightPHP code, so I made a path to make it work for my case. I think this change won't break old code but I'm not sure. I'm pusing it anyway so it show up on google for everyone who have this problem.
## My setup

```
./my-project
    /public
        /css
        /js
        .htaccess         [1]
        app.php           // FlightPHP app is here
        ...
    /vendor
    /config
    .htaccess             [2]
    ...
```

.htaccess [1]

```
RewriteEngine On
RewriteCond %{REQUEST_FILENAME} !-f
RewriteCond %{REQUEST_FILENAME} !-d
RewriteRule ^(.*)$ app.php?/$1 [L]
```

.htacces [2]

```
RewriteEngine On

RewriteCond %{REQUEST_URI} !public/.*$
RewriteRule ^(.*)$ public/$1 [L]
```

So when a user go to `http://website.com/my-project/` apache will actually load `http://website.com/my-project/public` which will load `http://website.com/my-project/app.php`.

`http://website.com/my-project/admin/action/xd` apache will actually load `http://website.com/my-project/public` which will load `http://website.com/my-project/app.php/admin/action/xd`.

`QUERY_STRING` = `/admin/action/xd/`.

Note that you still need to set `Flight::set('flight.base_url', '/my-project/');` to make redirects work.
