### PR TITLE
PHPDoc update & rearrangement

### DIFF
--- a/flight/Flight.php
+++ b/flight/Flight.php
@@ -8,28 +8,50 @@
 
 /**
  * The Flight class is a static representation of the framework.
- * 
- * @method  static void map($name, $callback) Creates a custom framework method.
- * @method  static void register($name, $class, array $params = array(), $callback = null) Registers a class to a framework method.
- * @method  static void before($name, $callback) Adds a filter before a framework method.
- * @method  static void after($name, $callback) Adds a filter after a framework method.
- * @method  static void path($path) Adds a path for autoloading classes.
- * @method  static mixed get($key) Gets a variable.
- * @method  static void set($key, $value) Sets a variable.
- * @method  static bool has($key) Checks if a variable is set.
- * @method  static void clear($key = null) Clears a variable.
+ *
+ * Core.
  * @method  static void start() Starts the framework.
+ * @method  static void path($path) Adds a path for autoloading classes.
  * @method  static void stop() Stops the framework and sends a response.
  * @method  static void halt($code = 200, $message = '') Stop the framework with an optional status code and message.
+ *
+ * Routing.
  * @method  static void route($pattern, $callback) Maps a URL pattern to a callback.
- * @method  static void redirect($url, $code = 303) Redirects to another URL.
+ * @method  static flight\net\Router router() Returns Router instance.
+ *
+ * Extending & Overriding.
+ * @method  static void map($name, $callback) Creates a custom framework method.
+ * @method  static void register($name, $class, array $params = array(), $callback = null) Registers a class to a
+ *          framework method.
+ *
+ * Filtering.
+ * @method  static void before($name, $callback) Adds a filter before a framework method.
+ * @method  static void after($name, $callback) Adds a filter after a framework method.
+ *
+ * Variables.
+ * @method  static void set($key, $value) Sets a variable.
+ * @method  static mixed get($key) Gets a variable.
+ * @method  static bool has($key) Checks if a variable is set.
+ * @method  static void clear($key = null) Clears a variable.
+ *
+ * Views.
  * @method  static void render($file, array $data = null, $key = null) Renders a template file.
- * @method  static void error($exception) Sends an HTTP 500 response.
- * @method  static void notFound() Sends an HTTP 404 response.
- * @method  static void etag($id, $type = 'strong') Performs ETag HTTP caching.
- * @method  static void lastModified($time) Performs last modified HTTP caching.
+ * @method  static flight\template\View view() Returns View instance.
+ *
+ * Redirects.
+ * @method  static void redirect($url, $code = 303) Redirects to another URL.
+ *
+ * Request & Response.
+ * @method  static flight\net\Request request() Returns Request instance.
+ * @method  static flight\net\Response response() Returns Request instance.
  * @method  static void json($data, $code = 200, $encode = true) Sends a JSON response.
  * @method  static void jsonp($data, $param = 'jsonp', $code = 200, $encode = true) Sends a JSONP response.
+ * @method  static void error($exception) Sends an HTTP 500 response.
+ * @method  static void notFound() Sends an HTTP 404 response.
+ *
+ * HTTP Caching.
+ * @method  static void etag($id, $type = 'strong') Performs ETag HTTP caching.
+ * @method  static void lastModified($time) Performs last modified HTTP caching.
  */
 class Flight {
     /**

--- a/flight/Flight.php
+++ b/flight/Flight.php
@@ -17,12 +17,11 @@
  *
  * Routing.
  * @method  static void route($pattern, $callback) Maps a URL pattern to a callback.
- * @method  static flight\net\Router router() Returns Router instance.
+ * @method  static \flight\net\Router router() Returns Router instance.
  *
  * Extending & Overriding.
  * @method  static void map($name, $callback) Creates a custom framework method.
- * @method  static void register($name, $class, array $params = array(), $callback = null) Registers a class to a
- *          framework method.
+ * @method  static void register($name, $class, array $params = array(), $callback = null) Registers a class to a framework method.
  *
  * Filtering.
  * @method  static void before($name, $callback) Adds a filter before a framework method.
@@ -36,11 +35,11 @@
  *
  * Views.
  * @method  static void render($file, array $data = null, $key = null) Renders a template file.
- * @method  static flight\template\View view() Returns View instance.
+ * @method  static \flight\template\View view() Returns View instance.
  *
  * Request & Response.
- * @method  static flight\net\Request request() Returns Request instance.
- * @method  static flight\net\Response response() Returns Request instance.
+ * @method  static \flight\net\Request request() Returns Request instance.
+ * @method  static \flight\net\Response response() Returns Request instance.
  * @method  static void redirect($url, $code = 303) Redirects to another URL.
  * @method  static void json($data, $code = 200, $encode = true) Sends a JSON response.
  * @method  static void jsonp($data, $param = 'jsonp', $code = 200, $encode = true) Sends a JSONP response.

--- a/flight/Flight.php
+++ b/flight/Flight.php
@@ -38,12 +38,10 @@
  * @method  static void render($file, array $data = null, $key = null) Renders a template file.
  * @method  static flight\template\View view() Returns View instance.
  *
- * Redirects.
- * @method  static void redirect($url, $code = 303) Redirects to another URL.
- *
  * Request & Response.
  * @method  static flight\net\Request request() Returns Request instance.
  * @method  static flight\net\Response response() Returns Request instance.
+ * @method  static void redirect($url, $code = 303) Redirects to another URL.
  * @method  static void json($data, $code = 200, $encode = true) Sends a JSON response.
  * @method  static void jsonp($data, $param = 'jsonp', $code = 200, $encode = true) Sends a JSONP response.
  * @method  static void error($exception) Sends an HTTP 500 response.


### PR DESCRIPTION
added `Flight::request()`, `Flight::response()`, `Flight::router()`, `Flight::view()` references to Flight PHPDoc section. Also did some rearrangement of methods in documentation.

Allows correct autocomplete for listed above methods in PHPStorm and (didn't test) other IDEs that supports PHPDoc.
