### PR TITLE
Changed Last-Modified HTTP header format

### DIFF
--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -507,7 +507,7 @@ class Engine {
      * @param int $time Unix timestamp
      */
     public function _lastModified($time) {
-        $this->response()->header('Last-Modified', date(DATE_RFC1123, $time));
+        $this->response()->header('Last-Modified', gmdate('D, d M Y H:i:s \G\M\T', $time));
 
         if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) &&
             strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) === $time) {


### PR DESCRIPTION
According to RFC2616, dates in HTTP headers should be in this format: "Thu, 03 Mar 2016 07:08:48 GMT".
Current implementation uses PHP constant "DATE_RFC1123" which produces date like this: "Thu, 03 Mar 2016 07:10:03 +0000".
