### PR TITLE
Second argument to get() function

### DIFF
--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -213,13 +213,14 @@ class Engine {
     /**
      * Gets a variable.
      *
-     * @param string $key Key
+     * @param string $key  Key
+     * @param string $skey Second key
      * @return mixed
      */
-    public function get($key = null) {
+    public function get($key = null, $sKey = null) {
         if ($key === null) return $this->vars;
 
-        return isset($this->vars[$key]) ? $this->vars[$key] : null;
+        return is_null($sKey) ? (isset($this->vars[$key]) ? $this->vars[$key] : null) : (isset($this->vars[$key][$sKey]) ? $this->vars[$key][$sKey] : null);
     }
 
     /**


### PR DESCRIPTION
Add second argument to get() function. Its need when we registering with set() function two-dimensional array.
