### PR TITLE
Fix redirect method due to a mistake removing backslashes

### DIFF
--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -430,7 +430,7 @@ class Engine {
 
         // Append base url to redirect url
         if ($base != '/' && strpos($url, '://') === false) {
-            $url = preg_replace('#/+#', '/', $base.'/'.$url);
+            $url = $base . preg_replace('#/+#', '/', '/' . $url);
         }
 
         $this->response(false)


### PR DESCRIPTION
The problem is that if 'flight.base_url' setting is set to 'http://localhost/flight', then:
$url = 'http:/localhost/flight';
Notice that one backslash has been removed.