### PR TITLE
Removed extraneous ->write($url) call on redirect that was causing Sa…

### DIFF
--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -437,7 +437,6 @@ class Engine {
             ->clear()
             ->status($code)
             ->header('Location', $url)
-            ->write($url)
             ->send();
     }
 


### PR DESCRIPTION
…fari to bugger out qwhen using HTTP2, which it tends to handle more strictly.

Notes:
The line above writes the URL to redirect to for the 303 then that line writes it again.
The result is a multi-line http header which causes safari to freak out when in http2 mode.
https://blog.christopherburg.com/2017/10/18/safari-11-multiline-http-headers-and-nsposixerrordomain100/
blog.christopherburg.com
Safari 11, Multiline HTTP Headers, and NSPOSIXErrorDomain:100. at A Geek With Guns
Chronicling the depravities of the State