### PR TITLE
add ability to call non-static methods

### DIFF
--- a/flight/core/Dispatcher.php
+++ b/flight/core/Dispatcher.php
@@ -191,7 +191,15 @@ class Dispatcher {
         list($class, $method) = $func;
 
         $instance = is_object($class);
-		
+
+        if (!$instance && method_exists($class, $method)) {
+            $methodChecker = new \ReflectionMethod($class, $method);
+            if (!$methodChecker->isStatic()) {
+                $class = new $class;
+                $instance = is_object($class);
+            }
+        }
+
         switch (count($params)) {
             case 0:
                 return ($instance) ?


### PR DESCRIPTION
Now you can call non-static methods. When there are many controllers on the web site, you need to initiate everything, and now one of them has been initialized.
You can do it:
`class Greeting
{
    public function __construct() {
        $this->name = 'John Doe';
    }

    public function hello() {
        echo "Hello, {$this->name}!";
    }
}

Flight::route('/', array('Greeting', 'hello')); `