### PR TITLE
Allow easy routing of URLs containing Cyrillic letters.

### DIFF
--- a/flight/net/Router.php
+++ b/flight/net/Router.php
@@ -78,8 +78,9 @@ class Router {
      * @return Route|bool Matching route or false if no match
      */
     public function route(Request $request) {
+        $url_decoded = urldecode( $request->url );
         while ($route = $this->current()) {
-            if ($route !== false && $route->matchMethod($request->method) && $route->matchUrl($request->url, $this->case_sensitive)) {
+            if ($route !== false && $route->matchMethod($request->method) && $route->matchUrl($url_decoded, $this->case_sensitive)) {
                 return $route;
             }
             $this->next();

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -263,4 +263,16 @@ class RouterTest extends PHPUnit_Framework_TestCase
 
         $this->check('404');
     }
+
+    
+    // Passing URL parameters matched with regular expression for a URL containing Cyrillic letters:
+    function testRegExParametersCyrillic(){
+        $this->router->map('/категория/@name:[абвгдеёжзийклмнопрстуфхцчшщъыьэюя]+', function($name){
+            echo $name;
+        });
+        $this->request->url = urlencode('/категория/цветя');
+
+        $this->check('цветя');
+    }
+    
 }


### PR DESCRIPTION
I want the ability to route URLs containing Cyrillic letters. 
For example: /категория/цветя  (in english: /category/flowers ). 

As it is, the url gets encoded in the request->url as '%2F%D0%BA%D0%B0%D1%82%D0%B5%D0%B3%D0%BE%D1%80%D0%B8%D1%8F%2F%D1%86%D0%B2%D0%B5%D1%82%D1%8F'

The patch in this pull request, gives flight the ability to match Cyrillic urls.
