### PR TITLE
 Update execute() method

### DIFF
--- a/flight/core/Dispatcher.php
+++ b/flight/core/Dispatcher.php
@@ -139,14 +139,25 @@ class Dispatcher {
      * @throws \Exception
      */
     public static function execute($callback, array &$params = array()) {
-        if (is_callable($callback)) {
-            return is_array($callback) ?
-                self::invokeMethod($callback, $params) :
-                self::callFunction($callback, $params);
-        }
-        else {
-            throw new \Exception('Invalid callback specified.');
-        }
+
+	if (is_array($callback) && is_string($callback[0]) && isset($callback[1])) {
+	    $classname = $callback[0];
+	    $method = $callback[1];
+	    if (class_exists($classname)) {
+		$r_method = new ReflectionMethod("$classname::$method");
+		if (!$r_method->isStatic())  //is not a static method
+		    $callback[0] = new $callback[0](); //instantiate object on the fly (Lorenzo Sanzari)
+	    } else {
+		throw new \Exception('The class ' . $callback[0] . ' does not exists!');
+	    }
+	}
+	if (is_callable($callback)) {
+	    return is_array($callback) ?
+		    self::invokeMethod($callback, $params) : //here, $callback is a string or an object
+		    self::callFunction($callback, $params);
+	} else {
+	    throw new \Exception('Invalid callback specified.');
+	}
     }
 
     /**

--- a/flight/template/View.php
+++ b/flight/template/View.php
@@ -152,23 +152,39 @@ class View {
     }
 
     /**
-     * Gets the full path to a template file.
+     * Load view from multiple folders using path prefix. 
+     * E.g.:
+     * Flight::set('theme.path','/home/myrootfolder/public/themes/current_theme')  //in app settings files
+     * 
+     * Flight::render('theme.path::myview', $params); 
      *
-     * @param string $file Template file
+     * @param string $file Template file with prefix
      * @return string Template file location
+     * 
+     * @author Lorenzo Sanzari
      */
     public function getTemplate($file) {
-        $ext = $this->extension;
 
-        if (!empty($ext) && (substr($file, -1 * strlen($ext)) != $ext)) {
-            $file .= $ext;
-        }
+	$ext = $this->extension;
 
-        if ((substr($file, 0, 1) == '/')) {
-            return $file;
-        }
-        
-        return $this->path.'/'.$file;
+	//Se il file non ha estensione, aggiugi estensione di default
+	if (!empty($ext) && (substr($file, -1 * strlen($ext)) != $ext)) {
+	    $file .= $ext;
+	}
+
+	
+	$parts = explode("::", $file);
+	if (count($parts) == 2) {
+	    $base_path_key = $parts[0];
+	    $file_path = $parts[1];
+	    return rtrim(App::get($base_path_key), "/") . "/" . $file_path;
+	}
+
+	if ((substr($file, 0, 1) == '/')) {
+	    return $file;
+	}
+
+	return $this->path . '/' . $file;
     }
 
     /**


### PR DESCRIPTION
In the official definition of Flight's routes, it is allowed to express the class callables as an array consisting of

[string, string] // static class 

or

[object , string] // object instance

In the second case, already in the definition we have to write:

[new MyClass (), 'myMethod']

which immediately causes the class constructor execution, and this can cause problems.

With the code proposed by me, however, the object instance will be created only when the route will actually be invoked.
So, even for non-static classes, we can simply write:

['myClass', 'myMethod']

avoiding the immediate execution of the constructor.