### PR TITLE
Add host to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,7 @@ files - Uploaded files
 secure - Whether the connection is secure
 accept - HTTP accept parameters
 proxy_ip - Proxy IP address of the client
+host - The request host name
 ```
 
 You can access the `query`, `data`, `cookies`, and `files` properties

--- a/flight/net/Request.php
+++ b/flight/net/Request.php
@@ -121,6 +121,11 @@ class Request {
     public $proxy_ip;
 
     /**
+     * @var string HTTP host name
+     */
+    public $host;
+
+    /**
      * Constructor.
      *
      * @param array $config Request configuration
@@ -145,7 +150,8 @@ class Request {
                 'files' => new Collection($_FILES),
                 'secure' => self::getVar('HTTPS', 'off') != 'off',
                 'accept' => self::getVar('HTTP_ACCEPT'),
-                'proxy_ip' => self::getProxyIpAddress()
+                'proxy_ip' => self::getProxyIpAddress(),
+                'host' => self::getVar('HTTP_HOST'),
             );
         }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -24,6 +24,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
         $_SERVER['HTTPS'] = 'on';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '32.32.32.32';
+        $_SERVER['HTTP_HOST'] = 'example.com';
 
         $this->request = new \flight\net\Request();
     }
@@ -39,6 +40,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, $this->request->length);
         $this->assertEquals(true, $this->request->secure);
         $this->assertEquals('', $this->request->accept);
+        $this->assertEquals('example.com', $this->request->host);
     }
 
     function testIpAddress() {


### PR DESCRIPTION
The requested host can be useful to build an url or route request based
on which host was used.