### PR TITLE
Allow generic middleware filtering using before and after

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # TODO
 
-Update tests
-Implements new tests
-Remove third paramaters in Flight::route(), merge it with the $config paramaters and replace the implementation with a middleware
-Change README to point to aleferri/flight instead of mikecao/flight (if he doesn't want to merge)
-Describe the change
+Update tests 
+Implements new tests 
+Change README to point to aleferri/flight instead of mikecao/flight (if he doesn't want to merge) 
+Describe the change 
 
 # What is Flight?
 
@@ -290,7 +289,7 @@ Flight::route('/', function($route){
 
     // Contains the contents of any '*' used in the URL pattern
     $route->splat;
-}, true);
+}, [ 'pass_route' => true ]);
 ```
 
 If you want to specify more parameters for http middleware usage (see later) you can add them as the third parameter
@@ -298,7 +297,7 @@ If you want to specify more parameters for http middleware usage (see later) you
 ```php
 Flight::route('/', function(){
     //Now every http middleware interested in your configuration will receive it
-}, false, [ 'MyKey' => true, 'AnotheryKey' => 2 ]);
+}, [ 'MyKey' => true, 'AnotheryKey' => 2 ]);
 ```
 
 # Extending

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Flight::start();
 # This Branch
 
 This branch has the goal to provide a viable and optional middleware stack implementation with the lightest modification to the current code.
-Sacrificating PSR compliance (Flight isn't PSR compliant anyway).
+No PSR compliant implementation is provided (Flight isn't PSR compliant anyway).
 
 # Requirements
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ No PSR compliant implementation is provided (Flight isn't PSR compliant anyway).
 
 # Requirements
 
-Flight requires `PHP 5.3` or greater.
-
-This branch requires `PHP 5.4` or greater due to short array initialization
+Thi branch of Flight requires `PHP 7` or greater due to the typed params for the functions and the short array initialization   
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# TODO
+
+Update tests
+Implements new tests
+Remove third paramaters in Flight::route(), merge it with the $config paramaters and replace the implementation with a middleware
+Change README to point to aleferri/flight instead of mikecao/flight (if he doesn't want to merge)
+Describe the change
+
 # What is Flight?
 
 Flight is a fast, simple, extensible framework for PHP. Flight enables you to 
@@ -324,20 +332,18 @@ Flight::map('dispatchRoute', function($route, $params){
     //when you are done
     Flight::_dispatchRoute($route, $params);
 });
+```
 
-// You can implement a sort of middleware stack too
+Or you can use the embedded fully optional LayersStack middlewares dispatcher to achieve what you want
 
-$stack = new MySuperCoolMiddlewareStack();
+```php
+$stack = new \flight\LayersStack( true ); //true if you don't want to remap the last call, false otherwise
 
-$stack->push( [ Flight::class, '_dispatchRoute' ] );
 $stack->push( [ MyCoolCachingMiddleware::class, 'process' ] );
-$stack->push( [ MyCoolCORSMiddleware::class, 'process' ] );
+$stack->push( [ MyCoolVisibilityMiddleware::class, 'process' ] );
 $stack->push( [ MyCoolErrorsMiddleware::class, 'process' ] );
 
-Flight::map('dispatchRoute', function($route, $params) use ($stack) {
-    //Now dispatch middleware stack
-    $stack->start($route, $params);
-});
+Flight::map( 'dispatchRoute', [ $stack, 'dispatch' ] );
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ Flight::route('/', function(){
 Flight::start();
 ```
 
+[Learn more](http://flightphp.com/learn)
+
+# This Branch
+
 This branch has the goal to provide a viable and optional middleware stack implementation with the lightest modification to the current code.
 Sacrificating PSR compliance (Flight isn't PSR compliant anyway).
-
-[Learn more](http://flightphp.com/learn)
 
 # Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # TODO
 
-Update tests 
-Implements new tests 
-Change README to point to aleferri/flight instead of mikecao/flight (if he doesn't want to merge) 
-Describe the change 
+Update tests   
+Implements new tests  
+Change README to point to aleferri/flight instead of mikecao/flight (if he doesn't want to merge)   
+Describe the change   
 
 # What is Flight?
 

--- a/README.md
+++ b/README.md
@@ -327,12 +327,12 @@ Flight::map('dispatchRoute', function($route, $params){
 
 // You can implement a sort of middleware stack too
 
-$stack = new MiddlewareStack();
+$stack = new MySuperCoolMiddlewareStack();
 
 $stack->push( [ Flight::class, '_dispatchRoute' ] );
-$stack->push( [ CachingMiddleware::class, 'process' ] );
-$stack->push( [ CORSMiddleware::class, 'process' ] );
-$stack->push( [ ErrorsMiddleware::class, 'process' ] );
+$stack->push( [ MyCoolCachingMiddleware::class, 'process' ] );
+$stack->push( [ MyCoolCORSMiddleware::class, 'process' ] );
+$stack->push( [ MyCoolErrorsMiddleware::class, 'process' ] );
 
 Flight::map('dispatchRoute', function($route, $params) use ($stack) {
     //Now dispatch middleware stack

--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -344,11 +344,6 @@ class Engine {
         while ($route = $router->route($request)) {
             $params = array_values($route->params);
 
-            // Add route info to the parameter list
-            if ($route->pass) {
-                $params[] = $route;
-            }
-
             // Call route handler
             $continue = $this->dispatchRoute($route, $params);
 
@@ -393,8 +388,8 @@ class Engine {
      * @param callback $callback Callback function
      * @param boolean $pass_route Pass the matching route object to the callback
      */
-    public function _route($pattern, $callback, $pass_route = false, $config = []) {
-        $this->router()->map($pattern, $callback, $pass_route, $config);
+    public function _route(string $pattern, $callback, array $config = []) {
+        $this->router()->map($pattern, $callback, $config);
     }
 
     /**

--- a/flight/LayersIterator.php
+++ b/flight/LayersIterator.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace flight;
+
+/**
+* LayersIterator iterate over the middlewares stack and call the next layer until it abort or reach the final layer (the route layer)
+*/
+class LayersIterator {
+
+    private $layers;
+    private $cursor;
+
+    /**
+    * @param array $layers stack of middleware layers
+    */
+    public function __construct(array $layers) {
+        $this->layers = $layers;
+        $this->cursor = count( $layers ) - 1;
+    }
+
+    /**
+    * Dispatch the next layer of the stack
+    * @param net\Route $route route found by the router
+    * @param array $params list of params for the route
+    * @param net\Request $request Flight request object
+    * @param net\Response $response Flight response object
+    * @return void
+    */
+    public function next(net\Route $route, array $params, net\Request $request, net\Response $response) {
+        if ( $this->cursor > -1 ) {
+            $callable = $this->layers[ $this->cursor ];
+            $this->cursor--;
+            call_user_func_array( $callable, [ $route, $params, $request, $response, $this ] );
+        }
+    }
+
+}

--- a/flight/LayersStack.php
+++ b/flight/LayersStack.php
@@ -22,20 +22,21 @@ class LayersStack {
     }
     
     /**
-    * Dispatch is a repeatable middlewares dispatch function that start the iteration on the current stack of layers before reaching the final route dispatch
+    * Dispatch is a repeatable middlewares dispatch function that start the iteration on the current stack of layers until there are no more
+    *
     * You shouldn't invoke it directly, instead map this method to Flight as "dispatchRoute" with Flight::map( 'dispatchRoute', [ $thisObject, 'dispatch' ] 
-    * overriding the original mapped method Flight::dispatchRoute and let Flight call it for you when it find a compatible route for the request.
-    * As it may found multiple routes compatibile with yours the repeatability of the dispatch function is a must
+    * overriding the original method and let Flight call it for you when it find a compatible route for the request.
+    * As the router may found multiple routes compatibile with yours the repeatability of the dispatch function is a must
     */
     public function dispatch(net\Route $route, array $params) {
-        $iterator = new LayersIterator( $this->layers );
+        $iterator = new layers\LayersIterator( $this->layers );
         $iterator->next($route, $params, \Flight::request(), \Flight::response);
     }
     
     /**
     * RealDispatch is a super thin wrapper over the original Flight::dispatchRoute
     */
-    public function realDispatch(net\Route $route, array $params, net\Request $request, net\Response $response, LayersIterator $iterator) {
+    public function realDispatch(net\Route $route, array $params, net\Request $request, net\Response $response, layers\LayersIterator $iterator) {
         \Flight::_dispatchRoute($route, $params);
     }
     

--- a/flight/LayersStack.php
+++ b/flight/LayersStack.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace flight;
+
+/*
+* LayersStack is a push down collection of middleware layers, at resolution they are resolved at inverted order
+*/
+class LayersStack {
+    
+    //Stack of layers
+    private $layers;
+    
+    /**
+    * Public constructor of the LayersStack
+    * @param bool $push_self push the realDispatch method as the final layer of the middlewares
+    */
+    public function __construct(bool $push_self = false) {
+        $this->stack = [];
+        if ( $push_self ) {
+            $this->stack[] = [ $this, 'realDispatch' ];
+        }
+    }
+    
+    /**
+    * Dispatch is a repeatable middlewares dispatch function that start the iteration on the current stack of layers before reaching the final route dispatch
+    * You shouldn't invoke it directly, instead map this method to Flight as "dispatchRoute" with Flight::map( 'dispatchRoute', [ $thisObject, 'dispatch' ] 
+    * overriding the original mapped method Flight::dispatchRoute and let Flight call it for you when it find a compatible route for the request.
+    * As it may found multiple routes compatibile with yours the repeatability of the dispatch function is a must
+    */
+    public function dispatch(net\Route $route, array $params) {
+        $iterator = new LayersIterator( $this->layers );
+        $iterator->next($route, $params, \Flight::request(), \Flight::response);
+    }
+    
+    /**
+    * RealDispatch is a super thin wrapper over the original Flight::dispatchRoute
+    */
+    public function realDispatch(net\Route $route, array $params, net\Request $request, net\Response $response, LayersIterator $iterator) {
+        \Flight::_dispatchRoute($route, $params);
+    }
+    
+}

--- a/flight/layers/FlightLayers.php
+++ b/flight/layers/FlightLayers.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace flight\layers;
+
+use flight\net\Route;
+use flight\net\Request;
+use flight\net\Response;
+
+class FlightLayers {
+    
+    /**
+    * Pass route to the callback if the 'pass_route' flag is true in the route configuration
+    */
+    public static function passRoute(Route $route, array $params, Request $request, Response $response, LayersIterator $iterator) {
+        if ( isset( $route->config['pass_route'] ) && $route->config['pass_route'] ) {
+            $params[] = $route;
+        }
+        $iterator->next($route, $params, $request, $response);
+    }
+    
+}

--- a/flight/layers/LayersIterator.php
+++ b/flight/layers/LayersIterator.php
@@ -1,6 +1,10 @@
 <?php
 
-namespace flight;
+namespace flight\layers;
+
+use flight\net\Route;
+use flight\net\Request;
+use flight\net\Response;
 
 /**
 * LayersIterator iterate over the middlewares stack and call the next layer until it abort or reach the final layer (the route layer)
@@ -20,13 +24,13 @@ class LayersIterator {
 
     /**
     * Dispatch the next layer of the stack
-    * @param net\Route $route route found by the router
+    * @param Route $route route found by the router
     * @param array $params list of params for the route
-    * @param net\Request $request Flight request object
-    * @param net\Response $response Flight response object
+    * @param Request $request Flight request object
+    * @param Response $response Flight response object
     * @return void
     */
-    public function next(net\Route $route, array $params, net\Request $request, net\Response $response) {
+    public function next(Route $route, array $params, Request $request, Response $response) {
         if ( $this->cursor > -1 ) {
             $callable = $this->layers[ $this->cursor ];
             $this->cursor--;

--- a/flight/net/Route.php
+++ b/flight/net/Route.php
@@ -50,6 +50,11 @@ class Route {
     public $pass = false;
 
     /**
+     * @var boolean Allow cors
+     */
+    public $cors_allowed = false;
+
+    /**
      * Constructor.
      *
      * @param string $pattern URL pattern
@@ -57,11 +62,12 @@ class Route {
      * @param array $methods HTTP methods
      * @param boolean $pass Pass self in callback parameters
      */
-    public function __construct($pattern, $callback, $methods, $pass) {
+    public function __construct($pattern, $callback, $methods, $pass, $cors_allowed) {
         $this->pattern = $pattern;
         $this->callback = $callback;
         $this->methods = $methods;
         $this->pass = $pass;
+        $this->cors_allowed = $cors_allowed;
     }
 
     /**

--- a/flight/net/Route.php
+++ b/flight/net/Route.php
@@ -50,9 +50,9 @@ class Route {
     public $pass = false;
 
     /**
-     * @var boolean Allow cors
+     * @var array Additional parameters for middlewares
      */
-    public $cors_allowed = false;
+    public $config = false;
 
     /**
      * Constructor.
@@ -62,12 +62,12 @@ class Route {
      * @param array $methods HTTP methods
      * @param boolean $pass Pass self in callback parameters
      */
-    public function __construct($pattern, $callback, $methods, $pass, $cors_allowed) {
+    public function __construct($pattern, $callback, $methods, $pass, $config) {
         $this->pattern = $pattern;
         $this->callback = $callback;
         $this->methods = $methods;
         $this->pass = $pass;
-        $this->cors_allowed = $cors_allowed;
+        $this->config = $config;
     }
 
     /**

--- a/flight/net/Route.php
+++ b/flight/net/Route.php
@@ -45,11 +45,6 @@ class Route {
     public $splat = '';
 
     /**
-     * @var boolean Pass self in callback parameters
-     */
-    public $pass = false;
-
-    /**
      * @var array Additional parameters for middlewares
      */
     public $config = false;
@@ -62,11 +57,10 @@ class Route {
      * @param array $methods HTTP methods
      * @param boolean $pass Pass self in callback parameters
      */
-    public function __construct($pattern, $callback, $methods, $pass, $config) {
+    public function __construct($pattern, $callback, $methods, $config) {
         $this->pattern = $pattern;
         $this->callback = $callback;
         $this->methods = $methods;
-        $this->pass = $pass;
         $this->config = $config;
     }
 

--- a/flight/net/Router.php
+++ b/flight/net/Router.php
@@ -58,7 +58,7 @@ class Router {
      * @param callback $callback Callback function
      * @param boolean $pass_route Pass the matching route object to the callback
      */
-    public function map($pattern, $callback, $pass_route = false, $cors_allowed = false) {
+    public function map($pattern, $callback, $pass_route = false, $config = []) {
         $url = $pattern;
         $methods = array('*');
 
@@ -68,7 +68,7 @@ class Router {
             $methods = explode('|', $method);
         }
 
-        $this->routes[] = new Route($url, $callback, $methods, $pass_route, $cors_allowed);
+        $this->routes[] = new Route($url, $callback, $methods, $pass_route, $config);
     }
 
     /**

--- a/flight/net/Router.php
+++ b/flight/net/Router.php
@@ -58,7 +58,7 @@ class Router {
      * @param callback $callback Callback function
      * @param boolean $pass_route Pass the matching route object to the callback
      */
-    public function map($pattern, $callback, $pass_route = false, $config = []) {
+    public function map($pattern, $callback, $config = []) {
         $url = $pattern;
         $methods = array('*');
 
@@ -68,7 +68,7 @@ class Router {
             $methods = explode('|', $method);
         }
 
-        $this->routes[] = new Route($url, $callback, $methods, $pass_route, $config);
+        $this->routes[] = new Route($url, $callback, $methods, $config);
     }
 
     /**

--- a/flight/net/Router.php
+++ b/flight/net/Router.php
@@ -11,7 +11,7 @@ namespace flight\net;
 /**
  * The Router class is responsible for routing an HTTP request to
  * an assigned callback function. The Router tries to match the
- * requested URL against a series of URL patterns. 
+ * requested URL against a series of URL patterns.
  */
 class Router {
     /**
@@ -58,7 +58,7 @@ class Router {
      * @param callback $callback Callback function
      * @param boolean $pass_route Pass the matching route object to the callback
      */
-    public function map($pattern, $callback, $pass_route = false) {
+    public function map($pattern, $callback, $pass_route = false, $cors_allowed = false) {
         $url = $pattern;
         $methods = array('*');
 
@@ -68,7 +68,7 @@ class Router {
             $methods = explode('|', $method);
         }
 
-        $this->routes[] = new Route($url, $callback, $methods, $pass_route);
+        $this->routes[] = new Route($url, $callback, $methods, $pass_route, $cors_allowed);
     }
 
     /**
@@ -114,4 +114,3 @@ class Router {
         $this->index = 0;
     }
 }
-


### PR DESCRIPTION
Add a generic route additional configuration parameter $config with default = []

Allow middleware filtering.

Flight::before( 'dispatchRoute', function(&$param, &$output) {
... //something you want to do before a route get dispatched, $param[0] is the current Route
});

Flight::after( 'dispatchRoute', function(&$param, &$output) {
... //cleanup after the route callback executed, $param[0] is the current Route
});