### PR TITLE
Trim url

### DIFF
--- a/flight/net/Router.php
+++ b/flight/net/Router.php
@@ -64,7 +64,7 @@ class Router {
 
         if (strpos($pattern, ' ') !== false) {
             list($method, $url) = explode(' ', trim($pattern), 2);
-
+            $url = trim($url);
             $methods = explode('|', $method);
         }
 


### PR DESCRIPTION
This helps support >=2 whitespaces between METHOD and URL:
```php
Flight::route('GET  /auth/nonce',           array($apiAuth, 'getNonce')); // `GET[space][space]/auth/nonce`
Flight::route('POST /auth/login/email',     array($apiAuth, 'loginByEmail'));
```