### PR TITLE
Add info about regex groups with named parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Flight::route('/@name/@id:[0-9]{3}', function($name, $id){
 });
 ```
 
+Matching regex groups `()` with named parameters isn't supported.
+
 ## Optional Parameters
 
 You can specify named parameters that are optional for matching by wrapping


### PR DESCRIPTION
I think this should be mentioned in the docs, see #277 and #324