### PR TITLE
PHP 8.1: Type declare length as int

### DIFF
--- a/flight/net/Request.php
+++ b/flight/net/Request.php
@@ -147,7 +147,7 @@ final class Request
                 'scheme' => self::getScheme(),
                 'user_agent' => self::getVar('HTTP_USER_AGENT'),
                 'type' => self::getVar('CONTENT_TYPE'),
-                'length' => (int)self::getVar('CONTENT_LENGTH', 0),
+                'length' => (int) self::getVar('CONTENT_LENGTH', 0),
                 'query' => new Collection($_GET),
                 'data' => new Collection($_POST),
                 'cookies' => new Collection($_COOKIE),

--- a/flight/net/Request.php
+++ b/flight/net/Request.php
@@ -147,7 +147,7 @@ final class Request
                 'scheme' => self::getScheme(),
                 'user_agent' => self::getVar('HTTP_USER_AGENT'),
                 'type' => self::getVar('CONTENT_TYPE'),
-                'length' => self::getVar('CONTENT_LENGTH', 0),
+                'length' => (int)self::getVar('CONTENT_LENGTH', 0),
                 'query' => new Collection($_GET),
                 'data' => new Collection($_POST),
                 'cookies' => new Collection($_COOKIE),


### PR DESCRIPTION
The following error is thrown when length is set to '10' instead of 10:
`TypeError: Cannot assign string to property flight\net\Request::$length of type int`