### PR TITLE
[2.x] Fix JSON request with empty body

### DIFF
--- a/flight/net/Request.php
+++ b/flight/net/Request.php
@@ -192,7 +192,7 @@ final class Request
         // Check for JSON input
         if (0 === strpos($this->type, 'application/json')) {
             $body = self::getBody();
-            if ('' !== $body) {
+            if ('' !== $body && null !== $body) {
                 $data = json_decode($body, true);
                 if (is_array($data)) {
                     $this->data->setData($data);

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -24,6 +24,12 @@ class RequestTest extends PHPUnit\Framework\TestCase
         $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
         $_SERVER['HTTP_X_FORWARDED_FOR'] = '32.32.32.32';
         $_SERVER['HTTP_HOST'] = 'example.com';
+        $_SERVER['CONTENT_TYPE'] = '';
+
+        $_GET = [];
+        $_POST = [];
+        $_COOKIE = [];
+        $_FILES = [];
 
         $this->request = new Request();
     }
@@ -85,6 +91,15 @@ class RequestTest extends PHPUnit\Framework\TestCase
         self::assertEquals(1, $request->data->q);
         self::assertEquals(1, $request->cookies->q);
         self::assertEquals(1, $request->files->q);
+    }
+
+    public function testJsonWithEmptyBody()
+    {
+        $_SERVER['CONTENT_TYPE'] = 'application/json';
+
+        $request = new Request();
+
+        self::assertSame([], $request->data->getData());
     }
 
     public function testMethodOverrideWithHeader()


### PR DESCRIPTION
Hi,

this PR fixes bug introduced in #439. Previously (1.x) loose comparison was used to check if body is empty, now (2.0) strict comparison is used. This changes behaviour when JSON body is empty. In that case the `Request::getBody()` returns `null`. It is then passed to `json_decode()` which fails with error:
```
TypeError: json_decode(): Argument #1 ($json) must be of type string, null given
```

I fixed it with adding explicit `$body !== null` check. I also added test which can trigger this error. Some changes in `RequestTest` was needed though to tests work correctly (reset of some variables to default state).