### PR TITLE
Remove __destruct() - Useless and may be removed

### DIFF
--- a/flight/Flight.php
+++ b/flight/Flight.php
@@ -72,10 +72,6 @@ class Flight
     {
     }
 
-    private function __destruct()
-    {
-    }
-
     private function __clone()
     {
     }


### PR DESCRIPTION
Related to: Fix #481

It's not an issue per-se, but as it is useless, I would remove.