### PR TITLE
fix testStaticFunctionMapping to actually map a static method

### DIFF
--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -92,11 +92,11 @@ class DispatcherTest extends TestCase
     // Map a static function
     public function testStaticFunctionMapping()
     {
-        $this->dispatcher->set('map2', 'tests\classes\Hello::sayHi');
+        $this->dispatcher->set('map2', 'tests\classes\Hello::sayBye');
 
         $result = $this->dispatcher->run('map2');
 
-        self::assertEquals('hello', $result);
+        self::assertEquals('goodbye', $result);
     }
 
     // Map a class method


### PR DESCRIPTION
The test was violating phps strict_types, did not test what the name suggested, and was failing. 