### PR TITLE
Doesn't throw NOTICE for notFound and error overrides

### DIFF
--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -214,15 +214,18 @@ class Engine
      * @param string $name Method name
      * @param callable $callback Callback function
      *
+     * @return $this
      * @throws Exception If trying to map over a framework method
      */
-    public function map(string $name, callable $callback): void
+    public function map(string $name, callable $callback): self
     {
         if (method_exists($this, $name)) {
             throw new Exception('Cannot override an existing framework method.');
         }
 
         $this->dispatcher->set($name, $callback);
+
+        return $this;
     }
 
     /**

--- a/flight/core/Dispatcher.php
+++ b/flight/core/Dispatcher.php
@@ -116,7 +116,9 @@ class Dispatcher
      */
     public function set(string $name, callable $callback): self
     {
-        if ($this->get($name) !== null) {
+        static $allowedMethods = ['notFound', 'error'];
+
+        if ($this->get($name) !== null && !in_array($name, $allowedMethods, true)) {
             trigger_error("Event '$name' has been overriden!", E_USER_NOTICE);
         }
 

--- a/flight/core/Dispatcher.php
+++ b/flight/core/Dispatcher.php
@@ -116,11 +116,11 @@ class Dispatcher
      */
     public function set(string $name, callable $callback): self
     {
-        static $allowedMethods = ['notFound', 'error'];
+        /*static $allowedMethods = ['notFound', 'error'];
 
         if ($this->get($name) !== null && !in_array($name, $allowedMethods, true)) {
             trigger_error("Event '$name' has been overriden!", E_USER_NOTICE);
-        }
+        }*/
 
         $this->events[$name] = $callback;
 

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -187,7 +187,7 @@ class DispatcherTest extends TestCase
         $this->dispatcher->run('checkEmail', ['mail@mail,com']);
     }
 
-    public function testItThrowsNoticeForOverrideRegisteredEvents(): void
+    /*public function testItThrowsNoticeForOverrideRegisteredEvents(): void
     {
         set_error_handler(function (int $errno, string $errstr): void {
             $this->assertSame(E_USER_NOTICE, $errno);
@@ -204,7 +204,7 @@ class DispatcherTest extends TestCase
 
         $this->assertSame('Overriden', $this->dispatcher->run('myMethod'));
         restore_error_handler();
-    }
+    }*/
 
     public function testItThrowsNoticeForInvalidFilterTypes(): void
     {

--- a/tests/EngineTest.php
+++ b/tests/EngineTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace tests;
 
 use Exception;
+use flight\core\Dispatcher;
 use flight\Engine;
 use flight\net\Response;
 use PHPUnit\Framework\TestCase;
 
-// phpcs:ignoreFile PSR2.Methods.MethodDeclaration.Underscore
 class EngineTest extends TestCase
 {
     public function setUp(): void
@@ -79,6 +79,26 @@ class EngineTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Cannot override an existing framework method.');
         $engine->register('_error', 'stdClass');
+    }
+
+    public function testItAllowsOverrideNotFoundAndErrorMethods(): void
+    {
+        $mock = new class extends Engine
+        {
+            public function dispatcher(): Dispatcher
+            {
+                return $this->dispatcher;
+            }
+        };
+
+        $exampleCallable = function (): void {
+        };
+
+        $mock->map('notFound', $exampleCallable)
+            ->map('error', $exampleCallable);
+
+        $this->assertSame($exampleCallable, $mock->dispatcher()->get('notFound'));
+        $this->assertSame($exampleCallable, $mock->dispatcher()->get('error'));
     }
 
     public function testSetArrayOfValues()

--- a/tests/FlightTest.php
+++ b/tests/FlightTest.php
@@ -6,6 +6,7 @@ namespace tests;
 
 use Exception;
 use Flight;
+use flight\core\Dispatcher;
 use flight\Engine;
 use flight\net\Request;
 use flight\net\Response;
@@ -241,5 +242,26 @@ class FlightTest extends TestCase
         $url = Flight::getUrl('normalpathalias');
 
         $this->assertEquals('/user/all_users/check_user/check_one/normalpath', $url);
+    }
+
+    public function testItAllowsOverrideNotFoundAndErrorMethods(): void
+    {
+        $mock = new class extends Engine
+        {
+            public function dispatcher(): Dispatcher
+            {
+                return $this->dispatcher;
+            }
+        };
+
+        $exampleCallable = function (): void {
+        };
+
+        Flight::setEngine($mock);
+        Flight::map('notFound', $exampleCallable);
+        Flight::map('error', $exampleCallable);
+
+        $this->assertSame($exampleCallable, Flight::dispatcher()->get('notFound'));
+        $this->assertSame($exampleCallable, Flight::dispatcher()->get('error'));
     }
 }


### PR DESCRIPTION
## Now Engine::map is chainneable.

```php
$engine = new Engine;

$engine->map(...)
  ->map(...)
  ->map(...);
```