### PR TITLE
added ability to overwrite the body

### DIFF
--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -575,6 +575,7 @@ class Engine
      * @param ?int $code HTTP status code
      *
      * @throws Exception
+     * @deprecated 3.5.3 This method will be removed in v4
      */
     public function _stop(?int $code = null): void
     {

--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -401,8 +401,8 @@ class Engine
                 continue;
             }
 
-            $use_v3_output_buffering = 
-                $this->response()->v2_output_buffering === false && 
+            $use_v3_output_buffering =
+                $this->response()->v2_output_buffering === false &&
                 $route->is_streamed === false;
 
             if ($use_v3_output_buffering === true) {
@@ -493,8 +493,8 @@ class Engine
                 }
             }
 
-            $use_v3_output_buffering = 
-                $this->response()->v2_output_buffering === false && 
+            $use_v3_output_buffering =
+                $this->response()->v2_output_buffering === false &&
                 $route->is_streamed === false;
 
             if ($use_v3_output_buffering === true) {

--- a/flight/net/Response.php
+++ b/flight/net/Response.php
@@ -225,13 +225,29 @@ class Response
      * Writes content to the response body.
      *
      * @param string $str Response content
+     * @param bool $overwrite Overwrite the response body
      *
      * @return $this Self reference
      */
-    public function write(string $str): self
+    public function write(string $str, bool $overwrite = false): self
     {
+        if ($overwrite === true) {
+            $this->clearBody();
+        }
+
         $this->body .= $str;
 
+        return $this;
+    }
+
+    /**
+     * Clears the response body.
+     *
+     * @return $this Self reference
+     */
+    public function clearBody(): self
+    {
+        $this->body = '';
         return $this;
     }
 
@@ -244,7 +260,7 @@ class Response
     {
         $this->status = 200;
         $this->headers = [];
-        $this->body = '';
+        $this->clearBody();
 
         // This needs to clear the output buffer if it's on
         if ($this->v2_output_buffering === false && ob_get_length() > 0) {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -238,4 +238,21 @@ class ResponseTest extends TestCase
         $response->send();
         $this->assertTrue($response->sent());
     }
+
+    public function testClearBody()
+    {
+        $response = new Response();
+        $response->write('test');
+        $response->clearBody();
+        $this->assertEquals('', $response->getBody());
+    }
+
+    public function testOverwriteBody()
+    {
+        $response = new Response();
+        $response->write('test');
+        $response->write('lots more test');
+        $response->write('new', true);
+        $this->assertEquals('new', $response->getBody());
+    }
 }

--- a/tests/server/LayoutMiddleware.php
+++ b/tests/server/LayoutMiddleware.php
@@ -77,6 +77,7 @@ class LayoutMiddleware
 <li><a href="/halt">Halt</a></li>
 <li><a href="/redirect">Redirect</a></li>
 <li><a href="/streamResponse">Stream</a></li>
+<li><a href="/overwrite">Overwrite Body</a></li>
 </ul>
 HTML;
         echo '<div id="container">';

--- a/tests/server/OverwriteBodyMiddleware.php
+++ b/tests/server/OverwriteBodyMiddleware.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+class OverwriteBodyMiddleware
+{
+    public function after()
+    {
+        $response = Flight::response();
+        $response->write(str_replace('<span style="color:red; font-weight: bold;">failed</span>', '<span style="color:green; font-weight: bold;">successfully works!</span>', $response->getBody()), true);
+    }
+}

--- a/tests/server/index.php
+++ b/tests/server/index.php
@@ -17,6 +17,7 @@ Flight::set('flight.views.extension', '.phtml');
 //Flight::set('flight.v2.output_buffering', true);
 
 require_once 'LayoutMiddleware.php';
+require_once 'OverwriteBodyMiddleware.php';
 
 Flight::group('', function () {
 
@@ -119,6 +120,10 @@ Flight::group('', function () {
         }
         echo "is successful!!";
     })->streamWithHeaders(['Content-Type' => 'text/html', 'status' => 200 ]);
+    // Test 14: Overwrite the body with a middleware
+    Flight::route('/overwrite', function () {
+        echo '<span id="infotext">Route text:</span> This route status is that it <span style="color:red; font-weight: bold;">failed</span>';
+    })->addMiddleware([new OverwriteBodyMiddleware()]);
 }, [ new LayoutMiddleware() ]);
 
 // Test 9: JSON output (should not output any other html)


### PR DESCRIPTION
Sometimes there is a need to overwrite the response body with a middleware or to change output based on some condition in your code logic. This allows better control over your responses.

This will only work in the new v3 output buffering as the v2 output buffering does not write everything to the response.