### PR TITLE
fix: handle encoded slashes for url parameters - fixes #552

### DIFF
--- a/flight/net/Router.php
+++ b/flight/net/Router.php
@@ -215,9 +215,8 @@ class Router
      */
     public function route(Request $request)
     {
-        $url_decoded = urldecode($request->url);
         while ($route = $this->current()) {
-            if ($route->matchMethod($request->method) && $route->matchUrl($url_decoded, $this->case_sensitive)) {
+            if ($route->matchMethod($request->method) && $route->matchUrl($request->url, $this->case_sensitive)) {
                 $this->executedRoute = $route;
                 return $route;
             }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -198,6 +198,16 @@ class RouterTest extends TestCase
         $this->check('123');
     }
 
+    public function testUrlParametersWithEncodedSlash()
+    {
+        $this->router->map('/redirect/@id', function ($id) {
+            echo $id;
+        });
+        $this->request->url = '/redirect/before%2Fafter';
+
+        $this->check('before/after');
+    }
+
     // Passing URL parameters matched with regular expression
     public function testRegExParameters()
     {
@@ -390,7 +400,7 @@ class RouterTest extends TestCase
         $this->router->map('/категория/@name:[абвгдеёжзийклмнопрстуфхцчшщъыьэюя]+', function ($name) {
             echo $name;
         });
-        $this->request->url = urlencode('/категория/цветя');
+        $this->request->url = '/' . urlencode('категория') . '/' . urlencode('цветя');
 
         $this->check('цветя');
     }


### PR DESCRIPTION
Caveat: technically, this introduces a backwards incompatible change, for instances where in the request URL (regular) slashes are encoded. I'd guess, that this is not relevant in regular setups and even though this was gracefully handled before, this change is neccessary to assure path params can contain encoded slashes.