### PR TITLE
Also register the HEAD method alongside GET

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     },
     "scripts": {
         "test": "phpunit",
-        "test-coverage": "rm clover.xml && XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html=coverage --coverage-clover=clover.xml && vendor/bin/coverage-check clover.xml 100",
+        "test-coverage": "rm -f clover.xml && XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html=coverage --coverage-clover=clover.xml && vendor/bin/coverage-check clover.xml 100",
         "test-server": "echo \"Running Test Server\" && php -S localhost:8000 -t tests/server/",
         "test-server-v2": "echo \"Running Test Server\" && php -S localhost:8000 -t tests/server-v2/",
         "test-coverage:win": "del clover.xml && phpunit --coverage-html=coverage --coverage-clover=clover.xml && coverage-check clover.xml 100",

--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -533,6 +533,11 @@ class Engine
             $dispatched = false;
         }
 
+        // HEAD requests should be identical to GET requests but have no body
+        if($request->method === 'HEAD') {
+            $response->clearBody();
+        }
+
         if ($failed_middleware_check === true) {
             $this->halt(403, 'Forbidden', empty(getenv('PHPUNIT_TEST')));
         } elseif ($dispatched === false) {

--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -534,7 +534,7 @@ class Engine
         }
 
         // HEAD requests should be identical to GET requests but have no body
-        if($request->method === 'HEAD') {
+        if ($request->method === 'HEAD') {
             $response->clearBody();
         }
 

--- a/flight/net/Router.php
+++ b/flight/net/Router.php
@@ -105,10 +105,11 @@ class Router
             [$method, $url] = explode(' ', $url, 2);
             $url = trim($url);
             $methods = explode('|', $method);
-        }
 
-        if (in_array('GET', $methods) && !in_array('HEAD', $methods)) {
-            $methods[] = 'HEAD';
+            // Add head requests to get methods, should they come in as a get request
+            if (in_array('GET', $methods, true) === true && in_array('HEAD', $methods, true) === false) {
+                $methods[] = 'HEAD';
+            }
         }
 
         // And this finishes it off.

--- a/flight/net/Router.php
+++ b/flight/net/Router.php
@@ -107,6 +107,10 @@ class Router
             $methods = explode('|', $method);
         }
 
+        if (in_array('GET', $methods) && !in_array('HEAD', $methods)) {
+            $methods[] = 'HEAD';
+        }
+
         // And this finishes it off.
         if ($this->group_prefix !== '') {
             $url = rtrim($this->group_prefix . $url);

--- a/tests/EngineTest.php
+++ b/tests/EngineTest.php
@@ -263,6 +263,20 @@ class EngineTest extends TestCase
         $this->assertEquals('/someRoute', $routes[0]->pattern);
     }
 
+    public function testHeadRoute()
+    {
+        $engine = new Engine();
+        $engine->route('GET /someRoute', function () {
+            echo 'i ran';
+        }, true);
+        $engine->request()->method = 'HEAD';
+        $engine->request()->url = '/someRoute';
+        $engine->start();
+
+        // No body should be sent
+        $this->expectOutputString('');
+    }
+
     public function testHalt()
     {
         $engine = new class extends Engine {

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -81,7 +81,7 @@ class RouterTest extends TestCase
             $dispatched = false;
         }
 
-        if($this->request->method === 'HEAD') {
+        if ($this->request->method === 'HEAD') {
             ob_clean();
         }
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -81,6 +81,10 @@ class RouterTest extends TestCase
             $dispatched = false;
         }
 
+        if($this->request->method === 'HEAD') {
+            ob_clean();
+        }
+
         if (!$dispatched) {
             echo '404';
         }
@@ -120,6 +124,15 @@ class RouterTest extends TestCase
         $this->request->method = 'GET';
 
         $this->check('OK');
+    }
+
+    public function testHeadRouteShortcut()
+    {
+        $route = $this->router->get('/path', [$this, 'ok']);
+        $this->assertEquals(['GET', 'HEAD'], $route->methods);
+        $this->request->url = '/path';
+        $this->request->method = 'HEAD';
+        $this->check('');
     }
 
     // POST route


### PR DESCRIPTION
Hi all! 

First off, thanks for Flight it's honestly a great little framework and It's been a treat to work with.

This is a very small patch that causes Flight to automatically register the HEAD method alongside GET if the user didn't do so manually. Per [the RFC](https://www.rfc-editor.org/rfc/rfc9110.html#HEAD), a server should respond identically to a HEAD request as a GET request except with only the headers.

The web-server in-front of PHP should ensure only the headers are sent back to the client, meaning the only aspect Flight needs to handle is just ensuring a HEAD request is handled the same as a GET request.

In terms of real-world use-case, I know that some uptime monitors (specifically updown.io) will try to use HEAD requests to save a little bit of bandwidth which would then fallback to GET requests when used with Flight.