### PR TITLE
Changed it so PdoWrapper returns collections

### DIFF
--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -63,6 +63,8 @@ use flight\net\Route;
  * # HTTP caching
  * @method void etag(string $id, ('strong'|'weak') $type = 'strong') Handles ETag HTTP caching.
  * @method void lastModified(int $time) Handles last modified HTTP caching.
+ *
+ * phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
  */
 class Engine
 {

--- a/flight/database/PdoWrapper.php
+++ b/flight/database/PdoWrapper.php
@@ -48,9 +48,8 @@ class PdoWrapper extends PDO
      */
     public function fetchField(string $sql, array $params = [])
     {
-        $collection_data = $this->fetchRow($sql, $params);
-        $array_data = $collection_data->getData();
-        return reset($array_data);
+        $result = $this->fetchRow($sql, $params);
+        return reset($result);
     }
 
     /**

--- a/flight/util/Collection.php
+++ b/flight/util/Collection.php
@@ -21,6 +21,18 @@ use JsonSerializable;
 class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
 {
     /**
+     * This is to allow for reset() to work properly.
+     *
+     * WARNING! This MUST be the first variable in this class!!!
+     *
+     * PHPStan is ignoring this because we don't need actually to read the property
+     *
+     * @var mixed
+     * @phpstan-ignore-next-line
+     */
+    private $first_property = null;
+
+    /**
      * Collection data.
      *
      * @var array<string, mixed>
@@ -35,6 +47,7 @@ class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
     public function __construct(array $data = [])
     {
         $this->data = $data;
+        $this->handleReset();
     }
 
     /**
@@ -55,6 +68,7 @@ class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
     public function __set(string $key, $value): void
     {
         $this->data[$key] = $value;
+        $this->handleReset();
     }
 
     /**
@@ -71,6 +85,7 @@ class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
     public function __unset(string $key): void
     {
         unset($this->data[$key]);
+        $this->handleReset();
     }
 
     /**
@@ -100,6 +115,7 @@ class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
         } else {
             $this->data[$offset] = $value;
         }
+        $this->handleReset();
     }
 
     /**
@@ -120,6 +136,17 @@ class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
     public function offsetUnset($offset): void
     {
         unset($this->data[$offset]);
+        $this->handleReset();
+    }
+
+    /**
+     * This is to allow for reset() of a Collection to work properly.
+     *
+     * @return void
+     */
+    public function handleReset()
+    {
+        $this->first_property = reset($this->data);
     }
 
     /**
@@ -207,6 +234,7 @@ class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
     public function setData(array $data): void
     {
         $this->data = $data;
+        $this->handleReset();
     }
 
     #[\ReturnTypeWillChange]

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -99,4 +99,27 @@ class CollectionTest extends TestCase
         $this->collection->clear();
         $this->assertEquals(0, $this->collection->count());
     }
+
+    public function testResetByProperty()
+    {
+        $this->collection->a = 11;
+        $this->collection->b = 22;
+        $result = reset($this->collection);
+        $this->assertEquals(11, $result);
+    }
+
+    public function testResetBySetData()
+    {
+        $this->collection->setData(['a' => 11, 'b' => 22]);
+        $result = reset($this->collection);
+        $this->assertEquals(11, $result);
+    }
+
+    public function testResetByArraySet()
+    {
+        $this->collection['a'] = 11;
+        $this->collection['b'] = 22;
+        $result = reset($this->collection);
+        $this->assertEquals(11, $result);
+    }
 }

--- a/tests/PdoWrapperTest.php
+++ b/tests/PdoWrapperTest.php
@@ -88,6 +88,13 @@ class PdoWrapperTest extends TestCase
         $this->assertEquals('three', $rows[2]['name']);
     }
 
+    public function testFetchAllNoRows()
+    {
+        $rows = $this->pdo_wrapper->fetchAll('SELECT * FROM test WHERE 1 = 2');
+        $this->assertCount(0, $rows);
+        $this->assertSame([], $rows);
+    }
+
     public function testFetchAllWithNamedParams()
     {
         $rows = $this->pdo_wrapper->fetchAll('SELECT * FROM test WHERE name = :name', [ 'name' => 'two']);


### PR DESCRIPTION
This used to return arrays for everything. It makes sense that it should return a collection so you can use it as an array or an object.