### PR TITLE
phpunit fixes for deprecated notices. Also Collection reset removal

### DIFF
--- a/flight/database/PdoWrapper.php
+++ b/flight/database/PdoWrapper.php
@@ -49,7 +49,8 @@ class PdoWrapper extends PDO
     public function fetchField(string $sql, array $params = [])
     {
         $result = $this->fetchRow($sql, $params);
-        return reset($result);
+        $data = $result->getData();
+        return reset($data);
     }
 
     /**

--- a/flight/util/Collection.php
+++ b/flight/util/Collection.php
@@ -21,18 +21,6 @@ use JsonSerializable;
 class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
 {
     /**
-     * This is to allow for reset() to work properly.
-     *
-     * WARNING! This MUST be the first variable in this class!!!
-     *
-     * PHPStan is ignoring this because we don't need actually to read the property
-     *
-     * @var mixed
-     * @phpstan-ignore-next-line
-     */
-    private $first_property = null;
-
-    /**
      * Collection data.
      *
      * @var array<string, mixed>
@@ -47,7 +35,6 @@ class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
     public function __construct(array $data = [])
     {
         $this->data = $data;
-        $this->handleReset();
     }
 
     /**
@@ -68,7 +55,6 @@ class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
     public function __set(string $key, $value): void
     {
         $this->data[$key] = $value;
-        $this->handleReset();
     }
 
     /**
@@ -85,7 +71,6 @@ class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
     public function __unset(string $key): void
     {
         unset($this->data[$key]);
-        $this->handleReset();
     }
 
     /**
@@ -115,7 +100,6 @@ class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
         } else {
             $this->data[$offset] = $value;
         }
-        $this->handleReset();
     }
 
     /**
@@ -136,17 +120,6 @@ class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
     public function offsetUnset($offset): void
     {
         unset($this->data[$offset]);
-        $this->handleReset();
-    }
-
-    /**
-     * This is to allow for reset() of a Collection to work properly.
-     *
-     * @return void
-     */
-    public function handleReset()
-    {
-        $this->first_property = reset($this->data);
     }
 
     /**
@@ -234,7 +207,6 @@ class Collection implements ArrayAccess, Iterator, Countable, JsonSerializable
     public function setData(array $data): void
     {
         $this->data = $data;
-        $this->handleReset();
     }
 
     #[\ReturnTypeWillChange]

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,6 +23,7 @@
     </testsuites>
     <logging />
     <php>
+        <ini name="error_reporting" value="-1"/>
         <env name="PHPUNIT_TEST" value="true" force="true" />
     </php>
 </phpunit>

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -99,27 +99,4 @@ class CollectionTest extends TestCase
         $this->collection->clear();
         $this->assertEquals(0, $this->collection->count());
     }
-
-    public function testResetByProperty()
-    {
-        $this->collection->a = 11;
-        $this->collection->b = 22;
-        $result = reset($this->collection);
-        $this->assertEquals(11, $result);
-    }
-
-    public function testResetBySetData()
-    {
-        $this->collection->setData(['a' => 11, 'b' => 22]);
-        $result = reset($this->collection);
-        $this->assertEquals(11, $result);
-    }
-
-    public function testResetByArraySet()
-    {
-        $this->collection['a'] = 11;
-        $this->collection['b'] = 22;
-        $result = reset($this->collection);
-        $this->assertEquals(11, $result);
-    }
 }

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -305,7 +305,7 @@ class DispatcherTest extends TestCase
     public function testExecuteStringClassDefaultContainerButForgotInjectingEngine(): void
     {
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessageMatches('#Argument 1 passed to tests\\\\classes\\\\ContainerDefault::__construct\(\) must be an instance of flight\\\\Engine, null given#');
+        $this->expectExceptionMessageMatches('#tests\\\\classes\\\\ContainerDefault::__construct\(\).+flight\\\\Engine, null given#');
         $result = $this->dispatcher->execute([ ContainerDefault::class, 'testTheContainer' ]);
     }
 }

--- a/tests/EngineTest.php
+++ b/tests/EngineTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace tests;
 
+use ErrorException;
 use Exception;
 use flight\database\PdoWrapper;
 use flight\Engine;
@@ -750,8 +751,8 @@ class EngineTest extends TestCase
         $engine->route('/container', Container::class.'->testThePdoWrapper');
         $engine->request()->url = '/container';
 
-        $this->expectException(PDOException::class);
-        $this->expectExceptionMessage("invalid data source name");
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessageMatches("/Passing null to parameter/");
 
         $engine->start();
     }


### PR DESCRIPTION
There's some deprecated notices that snuck through this. There also some issues with resetting a Collection so I removed the hack cause php8.1 didn't like it.