### PR TITLE
Added ability to load classes with _ in them

### DIFF
--- a/flight/core/Loader.php
+++ b/flight/core/Loader.php
@@ -26,6 +26,11 @@ class Loader
     protected array $classes = [];
 
     /**
+     * If this is disabled, classes can load with underscores
+     */
+    protected static bool $v2ClassLoading = true;
+
+    /**
      * Class instances.
      *
      * @var array<string, object>
@@ -190,14 +195,14 @@ class Loader
      */
     public static function loadClass(string $class): void
     {
-        $classFile = str_replace(['\\', '_'], '/', $class) . '.php';
+        $replace_chars = self::$v2ClassLoading === true ? ['\\', '_'] : ['\\'];
+        $classFile = str_replace($replace_chars, '/', $class) . '.php';
 
         foreach (self::$dirs as $dir) {
             $filePath = "$dir/$classFile";
 
             if (file_exists($filePath)) {
                 require_once $filePath;
-
                 return;
             }
         }
@@ -219,5 +224,18 @@ class Loader
                 self::$dirs[] = $dir;
             }
         }
+    }
+
+
+    /**
+     * Sets the value for V2 class loading.
+     *
+     * @param bool $value The value to set for V2 class loading.
+     *
+     * @return void
+     */
+    public static function setV2ClassLoading(bool $value): void
+    {
+        self::$v2ClassLoading = $value;
     }
 }

--- a/flight/util/ReturnTypeWillChange.php
+++ b/flight/util/ReturnTypeWillChange.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-// This file is only here so that the PHP8 attribute for doesn't throw an error in files
-// phpcs:ignoreFile PSR1.Classes.ClassDeclaration.MissingNamespace
-class ReturnTypeWillChange
-{
-}

--- a/tests/EngineTest.php
+++ b/tests/EngineTest.php
@@ -751,8 +751,14 @@ class EngineTest extends TestCase
         $engine->route('/container', Container::class.'->testThePdoWrapper');
         $engine->request()->url = '/container';
 
-        $this->expectException(ErrorException::class);
-        $this->expectExceptionMessageMatches("/Passing null to parameter/");
+        // php 7.4 will throw a PDO exception, but php 8 will throw an ErrorException
+        if(version_compare(PHP_VERSION, '8.0.0', '<')) {
+            $this->expectException(PDOException::class);
+            $this->expectExceptionMessageMatches("/invalid data source name/");
+        } else {
+            $this->expectException(ErrorException::class);
+            $this->expectExceptionMessageMatches("/Passing null to parameter/");
+        }
 
         $engine->start();
     }

--- a/tests/LoaderTest.php
+++ b/tests/LoaderTest.php
@@ -152,4 +152,17 @@ class LoaderTest extends TestCase
             __DIR__ . '/classes'
         ], $loader->getDirectories());
     }
+
+    public function testV2ClassLoading()
+    {
+        $loader = new class extends Loader {
+            public static function getV2ClassLoading()
+            {
+                return self::$v2ClassLoading;
+            }
+        };
+        $this->assertTrue($loader::getV2ClassLoading());
+        $loader::setV2ClassLoading(false);
+        $this->assertFalse($loader::getV2ClassLoading());
+    }
 }

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -1,9 +1,26 @@
 #!/bin/bash
 
-# Run all tests
-composer lint
-composer beautify
-composer phpcs
-composer test-coverage
-xdg-open http://localhost:8000
-composer test-server
+php_versions=("php7.4" "php8.0" "php8.1" "php8.2" "php8.3")
+
+count=${#php_versions[@]}
+
+
+echo "Prettifying code first"
+vendor/bin/phpcbf --standard=phpcs.xml
+
+set -e
+for ((i = 0; i < count; i++)); do
+    if type "${php_versions[$i]}" &> /dev/null; then
+        echo "Running tests for ${php_versions[$i]}"
+        echo "  ${php_versions[$i]} vendor/bin/phpunit"
+        ${php_versions[$i]} vendor/bin/phpunit
+
+        echo "Running PHPStan"
+        echo "  ${php_versions[$i]} vendor/bin/phpstan"
+        ${php_versions[$i]} vendor/bin/phpstan
+
+        echo "Running PHPCS"
+        echo "  ${php_versions[$i]} vendor/bin/phpcs --standard=phpcs.xml -n"
+        ${php_versions[$i]} vendor/bin/phpcs --standard=phpcs.xml -n
+    fi
+done

--- a/tests/server/LayoutMiddleware.php
+++ b/tests/server/LayoutMiddleware.php
@@ -83,6 +83,7 @@ class LayoutMiddleware
 <li><a href="/わたしはひとです/ええ">UTF8 URL w/ Param</a></li>
 <li><a href="/dice">Dice Container</a></li>
 <li><a href="/no-container">No Container Registered</a></li>
+<li><a href="/Pascal_Snake_Case">Pascal_Snake_Case</a></li>
 </ul>
 HTML;
         echo '<div id="container">';

--- a/tests/server/Pascal_Snake_Case.php
+++ b/tests/server/Pascal_Snake_Case.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+class Pascal_Snake_Case // phpcs:ignore
+{
+    public function doILoad() // phpcs:ignore
+    {
+        echo 'Yes, I load!!!';
+    }
+}

--- a/tests/server/index.php
+++ b/tests/server/index.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use flight\core\Loader;
 use flight\database\PdoWrapper;
 use tests\classes\Container;
 use tests\classes\ContainerDefault;
@@ -18,10 +19,8 @@ use tests\classes\ContainerDefault;
 Flight::set('flight.content_length', false);
 Flight::set('flight.views.path', './');
 Flight::set('flight.views.extension', '.phtml');
-//Flight::set('flight.v2.output_buffering', true);
-
-require_once 'LayoutMiddleware.php';
-require_once 'OverwriteBodyMiddleware.php';
+Loader::setV2ClassLoading(false);
+Flight::path(__DIR__);
 
 Flight::group('', function () {
 
@@ -147,6 +146,7 @@ Flight::group('', function () {
     Flight::set('test_me_out', 'You got it boss!'); // used in /no-container route
     Flight::route('/no-container', ContainerDefault::class . '->testUi');
     Flight::route('/dice', Container::class . '->testThePdoWrapper');
+    Flight::route('/Pascal_Snake_Case', Pascal_Snake_Case::class . '->doILoad');
 }, [ new LayoutMiddleware() ]);
 
 // Test 9: JSON output (should not output any other html)


### PR DESCRIPTION
This allows you to load a class in your codebase such as `Pascal_Snake_Case` and it will still work. You must set it with `Loader::setV2ClassLoading(false);`