### PR TITLE
Fix content length when using response body callbacks

### DIFF
--- a/flight/net/Response.php
+++ b/flight/net/Response.php
@@ -341,6 +341,15 @@ class Response
             );
         }
 
+        if ($this->content_length === true) {
+            // Send content length
+            $length = $this->getContentLength();
+
+            if ($length > 0) {
+                $this->setHeader('Content-Length', (string) $length);
+            }
+        }
+
         // Send other headers
         foreach ($this->headers as $field => $value) {
             if (\is_array($value)) {
@@ -349,15 +358,6 @@ class Response
                 }
             } else {
                 $this->setRealHeader($field . ': ' . $value);
-            }
-        }
-
-        if ($this->content_length) {
-            // Send content length
-            $length = $this->getContentLength();
-
-            if ($length > 0) {
-                $this->setRealHeader('Content-Length: ' . $length);
             }
         }
 
@@ -437,7 +437,7 @@ class Response
             $this->processResponseCallbacks();
         }
 
-        if (!headers_sent()) {
+        if (headers_sent() === false) {
             $this->sendHeaders(); // @codeCoverageIgnore
         }
 

--- a/flight/net/Response.php
+++ b/flight/net/Response.php
@@ -432,13 +432,13 @@ class Response
             }
         }
 
-        if (!headers_sent()) {
-            $this->sendHeaders(); // @codeCoverageIgnore
-        }
-
         // Only for the v3 output buffering.
         if ($this->v2_output_buffering === false) {
             $this->processResponseCallbacks();
+        }
+
+        if (!headers_sent()) {
+            $this->sendHeaders(); // @codeCoverageIgnore
         }
 
         echo $this->body;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -26,6 +26,7 @@
         <exclude name="Generic.Commenting.DocComment.ContentBeforeClose" />
         <exclude name="Generic.Commenting.DocComment.MissingShort" />
         <exclude name="Generic.Commenting.DocComment.SpacingBeforeShort" />
+        <exclude name="Generic.Formatting.NoSpaceAfterCast.SpaceFound" />
         <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine" />
         <exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning" />
         <exclude name="Generic.Functions.OpeningFunctionBraceBsdAllman.BraceOnSameLine" />

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -270,6 +270,22 @@ class ResponseTest extends TestCase
         $this->assertEquals('grfg', $rot13_body);
     }
 
+    public function testResponseBodyCallbackGzip()
+    {
+        $response = new Response();
+        $response->content_length = true;
+        $response->write('test');
+        $gzip = function ($body) {
+            return gzencode($body);
+        };
+        $response->addResponseBodyCallback($gzip);
+        ob_start();
+        $response->send();
+        $gzip_body = ob_get_clean();
+        $this->assertEquals('H4sIAAAAAAAAAytJLS4BAAx+f9gEAAAA', base64_encode($gzip_body));
+        $this->assertEquals(strlen(gzencode('test')), strlen($gzip_body));
+    }
+
     public function testResponseBodyCallbackMultiple()
     {
         $response = new Response();


### PR DESCRIPTION
#571 introduced an issue where the response body could be modified **after** Flight calculates & sends the content length to the browser. Since the response body callback modifies the body, the content length is no longer correct.

In my testing things seemed to still work okay locally with the PHP dev server, but once I moved to an [actual server](https://api.fossbilling.org/) I noticed the browser would sit and continue to try to load after the body has already sent as the response body was compressed after the content length was sent.

Switching the order so the callback is called and then headers are sent fixes this