### PR TITLE
Remove .vscode directory, and add it to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.idea
+.idea/
+.vscode/
 vendor/
 composer.phar
 composer.lock

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "php.suggest.basic": false,
-    "editor.detectIndentation": false,
-    "editor.insertSpaces": true
-}


### PR DESCRIPTION
Delete the `.vscode` directory, that had been reintroduced during #547, and add it back to the `.gitignore` file.

Helpful documentation: [Git - gitignore Documentation](https://git-scm.com/docs/gitignore), in particular the [Pattern Format section](https://git-scm.com/docs/gitignore#_pattern_format).

By the way, excluding these IDE directories seems to be unpopular, because it should be the user's responsibility to exclude the metadata from the editors he is using.

See for instance:
* https://github.com/laravel/framework/pull/19323
* https://github.com/laravel/framework/pull/22550
* https://github.com/laravel/framework/issues/37017

However, Taylor Otwell ended up adding these exclude lines, and I think the added convenience is worth these few extra lines.