### PR TITLE
Maintains headers on redirect, error, and halt. Added jsonHalt

### DIFF
--- a/flight/Flight.php
+++ b/flight/Flight.php
@@ -68,6 +68,8 @@ require_once __DIR__ . '/autoload.php';
  * @method static void redirect(string $url, int $code = 303) Redirects to another URL.
  * @method static void json(mixed $data, int $code = 200, bool $encode = true, string $charset = "utf8", int $encodeOption = 0, int $encodeDepth = 512)
  * Sends a JSON response.
+ * @method void jsonHalt(mixed $data, int $code = 200, bool $encode = true, string $charset = 'utf-8', int $option = 0)
+ * Sends a JSON response and immediately halts the request.
  * @method static void jsonp(mixed $data, string $param = 'jsonp', int $code = 200, bool $encode = true, string $charset = "utf8", int $encodeOption = 0, int $encodeDepth = 512)
  * Sends a JSONP response.
  * @method static void error(Throwable $exception) Sends an HTTP 500 response.

--- a/tests/EngineTest.php
+++ b/tests/EngineTest.php
@@ -370,6 +370,16 @@ class EngineTest extends TestCase
         $this->assertEquals(200, $engine->response()->status());
     }
 
+	public function testJsonHalt()
+    {
+        $engine = new Engine();
+		$this->expectOutputString('{"key1":"value1","key2":"value2"}');
+        $engine->jsonHalt(['key1' => 'value1', 'key2' => 'value2']);
+        $this->assertEquals('application/json; charset=utf-8', $engine->response()->headers()['Content-Type']);
+        $this->assertEquals(200, $engine->response()->status());
+		$this->assertEquals('{"key1":"value1","key2":"value2"}', $engine->response()->getBody());
+    }
+
     public function testJsonP()
     {
         $engine = new Engine();

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -631,6 +631,10 @@ class RouterTest extends TestCase
         $this->router->rewind();
         $result = $this->router->valid();
         $this->assertTrue($result);
+
+        $this->router->previous();
+        $result = $this->router->valid();
+        $this->assertFalse($result);
     }
 
     public function testGetRootUrlByAlias()

--- a/tests/server-v2/index.php
+++ b/tests/server-v2/index.php
@@ -116,6 +116,10 @@ Flight::route('/jsonp', function () {
     echo "\n\n\n\n\n";
 });
 
+Flight::route('/json-halt', function () {
+    Flight::jsonHalt(['message' => 'JSON rendered and halted successfully with no other body content!']);
+});
+
 // Test 10: Halt
 Flight::route('/halt', function () {
     Flight::halt(400, 'Halt worked successfully');
@@ -200,6 +204,7 @@ echo '
 <li><a href="/error">Error</a></li>
 <li><a href="/json">JSON</a></li>
 <li><a href="/jsonp?jsonp=myjson">JSONP</a></li>
+<li><a href="/json-halt">JSON Halt</a></li>
 <li><a href="/halt">Halt</a></li>
 <li><a href="/redirect">Redirect</a></li>
 </ul>';

--- a/tests/server/LayoutMiddleware.php
+++ b/tests/server/LayoutMiddleware.php
@@ -74,6 +74,7 @@ class LayoutMiddleware
 <li><a href="/error">Error</a></li>
 <li><a href="/json">JSON</a></li>
 <li><a href="/jsonp?jsonp=myjson">JSONP</a></li>
+<li><a href="/json-halt">JSON Halt</a></li>
 <li><a href="/halt">Halt</a></li>
 <li><a href="/redirect">Redirect</a></li>
 <li><a href="/streamResponse">Stream Plain</a></li>

--- a/tests/server/index.php
+++ b/tests/server/index.php
@@ -171,6 +171,10 @@ Flight::route('/jsonp', function () {
     Flight::jsonp(['message' => 'JSONP renders successfully!'], 'jsonp');
 });
 
+Flight::route('/json-halt', function () {
+    Flight::jsonHalt(['message' => 'JSON rendered and halted successfully with no other body content!']);
+});
+
 Flight::map('error', function (Throwable $e) {
     echo sprintf(
         <<<HTML


### PR DESCRIPTION
Instead of clearing out the headers that have been set in the response, this will only clear the body instead, which is more desirable.

Additionally, this adds a new mappable method `jsonHalt()` which will output your JSON and immediately stop the request.