### PR TITLE
Changed default cache behavior

### DIFF
--- a/flight/net/Response.php
+++ b/flight/net/Response.php
@@ -288,7 +288,7 @@ class Response
     {
         if ($expires === false) {
             $this->headers['Expires'] = 'Mon, 26 Jul 1997 05:00:00 GMT';
-            $this->headers['Cache-Control'] = 'no-store, no-cache, must-revalidate';
+            $this->headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, max-age=0';
             $this->headers['Pragma'] = 'no-cache';
         } else {
             $expires = \is_int($expires) ? $expires : strtotime($expires);
@@ -432,11 +432,10 @@ class Response
         }
 
         if ($this->headersSent() === false) {
-
-			// If you haven't set a Cache-Control header, we'll assume you don't want caching
-			if($this->getHeader('Cache-Control') === null) {
-				$this->cache(false);
-			}
+            // If you haven't set a Cache-Control header, we'll assume you don't want caching
+            if ($this->getHeader('Cache-Control') === null) {
+                $this->cache(false);
+            }
 
             $this->sendHeaders();
         }
@@ -446,16 +445,16 @@ class Response
         $this->sent = true;
     }
 
-	/**
-	 * Headers have been sent
-	 * 
-	 * @return bool
-	 * @codeCoverageIgnore
-	 */
-	public function headersSent(): bool
-	{
-		return headers_sent();
-	}
+    /**
+     * Headers have been sent
+     *
+     * @return bool
+     * @codeCoverageIgnore
+     */
+    public function headersSent(): bool
+    {
+        return headers_sent();
+    }
 
     /**
      * Adds a callback to process the response body before it's sent. These are processed in the order

--- a/flight/net/Response.php
+++ b/flight/net/Response.php
@@ -288,13 +288,7 @@ class Response
     {
         if ($expires === false) {
             $this->headers['Expires'] = 'Mon, 26 Jul 1997 05:00:00 GMT';
-
-            $this->headers['Cache-Control'] = [
-                'no-store, no-cache, must-revalidate',
-                'post-check=0, pre-check=0',
-                'max-age=0',
-            ];
-
+            $this->headers['Cache-Control'] = 'no-store, no-cache, must-revalidate';
             $this->headers['Pragma'] = 'no-cache';
         } else {
             $expires = \is_int($expires) ? $expires : strtotime($expires);
@@ -437,14 +431,31 @@ class Response
             $this->processResponseCallbacks();
         }
 
-        if (headers_sent() === false) {
-            $this->sendHeaders(); // @codeCoverageIgnore
+        if ($this->headersSent() === false) {
+
+			// If you haven't set a Cache-Control header, we'll assume you don't want caching
+			if($this->getHeader('Cache-Control') === null) {
+				$this->cache(false);
+			}
+
+            $this->sendHeaders();
         }
 
         echo $this->body;
 
         $this->sent = true;
     }
+
+	/**
+	 * Headers have been sent
+	 * 
+	 * @return bool
+	 * @codeCoverageIgnore
+	 */
+	public function headersSent(): bool
+	{
+		return headers_sent();
+	}
 
     /**
      * Adds a callback to process the response body before it's sent. These are processed in the order

--- a/tests/FlightTest.php
+++ b/tests/FlightTest.php
@@ -361,8 +361,7 @@ class FlightTest extends TestCase
         string $output,
         array $renderParams,
         string $regexp
-    ): void
-    {
+    ): void {
         Flight::view()->preserveVars = false;
 
         $this->expectOutputString($output);

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -164,7 +164,7 @@ class ResponseTest extends TestCase
         $response->cache(false);
         $this->assertEquals([
             'Expires' => 'Mon, 26 Jul 1997 05:00:00 GMT',
-            'Cache-Control' => 'no-store, no-cache, must-revalidate',
+            'Cache-Control' => 'no-store, no-cache, must-revalidate, max-age=0',
             'Pragma' => 'no-cache'
         ], $response->headers());
     }
@@ -235,8 +235,8 @@ class ResponseTest extends TestCase
         $this->assertTrue($response->sent());
     }
 
-	public function testSendWithNoHeadersSent()
-	{
+    public function testSendWithNoHeadersSent()
+    {
         $response = new class extends Response {
             protected $test_sent_headers = [];
 
@@ -251,16 +251,16 @@ class ResponseTest extends TestCase
                 return $this->test_sent_headers;
             }
 
-			public function headersSent(): bool
-			{
-				return false;
-			}
+            public function headersSent(): bool
+            {
+                return false;
+            }
         };
         $response->header('Content-Type', 'text/html');
         $response->header('X-Test', 'test');
         $response->write('Something');
 
-		$this->expectOutputString('Something');
+        $this->expectOutputString('Something');
 
         $response->send();
         $sent_headers = $response->getSentHeaders();
@@ -268,9 +268,9 @@ class ResponseTest extends TestCase
             'HTTP/1.1 200 OK',
             'Content-Type: text/html',
             'X-Test: test',
-			'Expires: Mon, 26 Jul 1997 05:00:00 GMT',
-            'Cache-Control: no-store, no-cache, must-revalidate',
-			'Pragma: no-cache',
+            'Expires: Mon, 26 Jul 1997 05:00:00 GMT',
+            'Cache-Control: no-store, no-cache, must-revalidate, max-age=0',
+            'Pragma: no-cache',
             'Content-Length: 9'
         ], $sent_headers);
     }


### PR DESCRIPTION
If you didn't specify a default cache behavior, then the browser could boss around your routes and create a lot of confusion. This should fix that so that you have to explicitly cache your routes for them to be cached. Usually you only cache your GET and HEAD requests.