### PR TITLE
fix: can send Json even if Flight is not started yet

### DIFF
--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -913,7 +913,11 @@ class Engine
             ->status($code)
             ->header('Content-Type', 'application/json')
             ->write($json);
-        if ($this->response()->v2_output_buffering === true) {
+
+        if (
+            $this->response()->v2_output_buffering === true
+            || ($this->requestHandled === false && empty(getenv('PHPUNIT_TEST')))
+        ) {
             $this->response()->send();
         }
     }


### PR DESCRIPTION
With FlightPHP v2, we could send JSON easily, even if the method `start()` was not called yet.

Example: 
```php
require_once __DIR__ . '/vendor/autoload.php';

Flight::json("Hello");
```

Now, with v3, nothing happens unless the framework is started with `Flight::start()` (and it seems requiring router defined, otherwise it returns a 404 error).

This pull request aims to restore the simple behavior of Flight v2 to send a JSON.

