### PR TITLE
test: re-run tests automatically with phpunit-watcher when a change is made

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
                   extensions: curl, mbstring
                   tools: composer:v2
             - run: composer install
-            - run: composer test
+            - run: composer test-ci

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^9.6",
         "rregeer/phpunit-coverage-check": "^0.3.1",
+        "spatie/phpunit-watcher": "^1.23 || ^1.24",
         "squizlabs/php_codesniffer": "^3.11"
     },
     "config": {
@@ -61,7 +62,8 @@
         "sort-packages": true
     },
     "scripts": {
-        "test": "phpunit",
+        "test": "vendor/bin/phpunit-watcher watch",
+        "test-ci": "phpunit",
         "test-coverage": "rm -f clover.xml && XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html=coverage --coverage-clover=clover.xml && vendor/bin/coverage-check clover.xml 100",
         "test-server": "echo \"Running Test Server\" && php -S localhost:8000 -t tests/server/",
         "test-server-v2": "echo \"Running Test Server\" && php -S localhost:8000 -t tests/server-v2/",

--- a/phpunit-watcher.yml
+++ b/phpunit-watcher.yml
@@ -1,0 +1,13 @@
+hideManual: true
+watch:
+  directories:
+    - tests
+    - flight
+  fileMask: '*.php'
+notifications:
+  passingTests: false
+  failingTests: false
+phpunit:
+  binaryPath: ./vendor/bin/phpunit
+  arguments: '--stop-on-failure'
+  timeout: 180


### PR DESCRIPTION
That is much more comfortable than restarting tests manually when a change is made

The command to run tests remains unchanged:

```bash
composer test
```