### PR TITLE
Simplify git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/.gemini export-ignore
 /.github export-ignore
 /tests export-ignore
 /.editorconfig export-ignore
@@ -5,5 +6,8 @@
 /.gitignore export-ignore
 /phpcs.xml export-ignore
 /phpstan.neon export-ignore
+/CONTRIBUTING.md export-ignore
+/index.php export-ignore
 /phpstan-baseline.neon export-ignore
 /phpunit.xml export-ignore
+/phpunit-watcher.yml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,10 +4,10 @@
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
-/phpcs.xml export-ignore
-/phpstan.neon export-ignore
 /CONTRIBUTING.md export-ignore
 /index.php export-ignore
+/phpcs.xml.dist export-ignore
 /phpstan-baseline.neon export-ignore
-/phpunit.xml export-ignore
+/phpstan.dist.neon export-ignore
 /phpunit-watcher.yml export-ignore
+/phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ coverage/
 *.sublime*
 clover.xml
 phpcs.xml
+phpstan.neon
+phpunit.xml
 .runway-config.json
 .runway-creds.json
 .DS_Store

--- a/composer.json
+++ b/composer.json
@@ -82,11 +82,13 @@
             "rm server.pid",
             "echo \"Performance Tests Completed.\""
         ],
-        "lint": "phpstan --no-progress --memory-limit=256M -cphpstan.neon",
+        "lint": "phpstan --no-progress --memory-limit=256M",
         "beautify": "phpcbf --standard=phpcs.xml",
         "phpcs": "phpcs --standard=phpcs.xml -n",
         "post-install-cmd": [
-            "php -r \"if (!file_exists('phpcs.xml')) copy('phpcs.xml.dist', 'phpcs.xml');\""
+            "php -r \"if (!file_exists('phpcs.xml')) copy('phpcs.xml.dist', 'phpcs.xml');\"",
+            "php -r \"if (!file_exists('phpstan.neon')) copy('phpstan.dist.neon', 'phpstan.neon');\"",
+            "php -r \"if (!file_exists('phpunit.xml')) copy('phpunit.xml.dist', 'phpunit.xml');\""
         ]
     },
     "suggest": {

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,14 @@
+includes:
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 6
+    excludePaths:
+        - vendor
+        - flight/util/ReturnTypeWillChange.php
+        - tests/named-arguments
+    paths:
+        - flight
+        - index.php
+    treatPhpDocTypesAsCertain: false

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    bootstrap="tests/phpunit_autoload.php"
+    executionOrder="random"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTodoAnnotatedTests="true"
+    convertDeprecationsToExceptions="true"
+    stopOnError="true"
+    stopOnFailure="true"
+    verbose="true"
+    colors="true">
+    <coverage processUncoveredFiles="false">
+        <include>
+            <directory suffix=".php">flight/</directory>
+        </include>
+		<exclude>
+			<file>flight/autoload.php</file>
+		</exclude>
+    </coverage>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests/</directory>
+            <exclude>tests/named-arguments/</exclude>
+        </testsuite>
+    </testsuites>
+    <logging />
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="PHPUNIT_TEST" value="true" force="true" />
+    </php>
+</phpunit>


### PR DESCRIPTION
This pull request introduces several improvements to the project's configuration files, primarily to standardize and modernize the handling of code quality tools and test configuration. The main changes include adding new default configuration files for PHPStan and PHPUnit, updating `.gitattributes` to better manage exported files, and enhancing the Composer scripts to ensure necessary config files are available after installation.

**Configuration management improvements:**

* Added `phpstan.dist.neon` as the new default PHPStan configuration file, specifying analysis level, included paths, and exclusions.
* Added `phpunit.xml.dist` as the new default PHPUnit configuration file, defining test suites, coverage options, and strictness settings.
* Updated Composer scripts in `composer.json` to automatically copy `phpstan.dist.neon` to `phpstan.neon` and `phpunit.xml.dist` to `phpunit.xml` if they do not exist, ensuring consistent local configuration for developers.

**Export and distribution adjustments:**

* Updated `.gitattributes` to exclude new configuration files (`phpstan.dist.neon`, `phpunit.xml.dist`, etc.) and other files from package exports, while removing obsolete or renamed entries.