### PR TITLE
simplify composer scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
                   extensions: curl, mbstring
                   tools: composer:v2
             - run: composer install
-            - run: composer test-ci
+            - run: composer test

--- a/composer.json
+++ b/composer.json
@@ -64,18 +64,30 @@
         "sort-packages": true
     },
     "scripts": {
-        "test": "@php vendor/bin/phpunit",
-        "test-watcher": "@php vendor/bin/phpunit-watcher watch",
-        "test-ci": "@php vendor/bin/phpunit",
+        "test": "phpunit",
+        "test-watcher": [
+            "phpunit-watcher || composer global require spatie/phpunit-watcher --dev",
+            "phpunit-watcher watch"
+        ],
         "test-coverage": [
             "rm -f clover.xml",
             "@putenv XDEBUG_MODE=coverage",
-            "@php vendor/bin/phpunit --coverage-html=coverage --coverage-clover=clover.xml",
-            "@php vendor/bin/coverage-check clover.xml 100"
+            "phpunit --coverage-html=coverage --coverage-clover=clover.xml",
+            "coverage-check clover.xml 100"
         ],
-        "test-server": "echo \"Running Test Server\" && @php -S localhost:8000 -t tests/server/",
-        "test-server-v2": "echo \"Running Test Server\" && @php -S localhost:8000 -t tests/server-v2/",
-        "test-coverage:win": "del clover.xml && phpunit --coverage-html=coverage --coverage-clover=clover.xml && coverage-check clover.xml 100",
+        "test-server": [
+            "echo \"Running Test Server\"",
+            "@php -S localhost:8000 -t tests/server"
+        ],
+        "test-server-v2": [
+            "echo \"Running Test Server\"",
+            "@php -S localhost:8000 -t tests/server-v2"
+        ],
+        "test-coverage:win": [
+            "del clover.xml",
+            "phpunit --coverage-html=coverage --coverage-clover=clover.xml",
+            "coverage-check clover.xml 100"
+        ],
         "test-performance": [
             "echo \"Running Performance Tests...\"",
             "@php -S localhost:8077 -t tests/performance/ > /dev/null 2>&1 & echo $! > server.pid",
@@ -86,12 +98,12 @@
             "echo \"Performance Tests Completed.\""
         ],
         "lint": "phpstan --no-progress --memory-limit=256M",
-        "beautify": "phpcbf --standard=phpcs.xml",
+        "beautify": "phpcbf",
         "phpcs": "phpcs",
         "post-install-cmd": [
-            "php -r \"if (!file_exists('phpcs.xml')) copy('phpcs.xml.dist', 'phpcs.xml');\"",
-            "php -r \"if (!file_exists('phpstan.neon')) copy('phpstan.dist.neon', 'phpstan.neon');\"",
-            "php -r \"if (!file_exists('phpunit.xml')) copy('phpunit.xml.dist', 'phpunit.xml');\""
+            "@php -r \"if (!file_exists('phpcs.xml')) copy('phpcs.xml.dist', 'phpcs.xml');\"",
+            "@php -r \"if (!file_exists('phpstan.neon')) copy('phpstan.dist.neon', 'phpstan.neon');\"",
+            "@php -r \"if (!file_exists('phpunit.xml')) copy('phpunit.xml.dist', 'phpunit.xml');\""
         ]
     },
     "suggest": {


### PR DESCRIPTION
This pull request updates the Composer scripts to streamline test commands, improve cross-platform compatibility, and simplify script definitions. The changes also update the GitHub Actions workflow to use the new test script. The most important changes are:

**Testing Scripts and Workflow:**

* Replaced the `test-ci` script with the standard `test` script in the GitHub Actions workflow, so CI now uses `composer test` instead of `composer test-ci`. (`.github/workflows/test.yml`)
* Simplified the `test` script to directly call `phpunit` instead of referencing the vendor binary, and removed the redundant `test-ci` script. (`composer.json`)
* Updated the `test-watcher` script to attempt running `phpunit-watcher` and install it globally if not present, making it more robust for local development. (`composer.json`)

**Cross-Platform and Script Improvements:**

* Refactored test server and coverage scripts to use array syntax for better readability and maintainability, and added a Windows-specific coverage script (`test-coverage:win`). (`composer.json`)
* Simplified the `beautify` script to remove the coding standard specification, and updated post-install commands to use the `@php` prefix for consistency. (`composer.json`)