### PR TITLE
fix wildcard routes being skipped by fast path method lookup closes #693

### DIFF
--- a/flight/net/Router.php
+++ b/flight/net/Router.php
@@ -152,7 +152,7 @@ class Router
             if (!isset($this->routesByMethod[$method])) {
                 $this->routesByMethod[$method] = [];
             }
-            $this->routesByMethod[$method][] = $route;
+            $this->routesByMethod[$method][count($this->routes) - 1] = $route;
         }
 
         return $route;
@@ -270,17 +270,13 @@ class Router
         }
 
         // Fast path: check method-specific routes first, then wildcard routes (only on first routing attempt)
-        $methodsToCheck = [$requestMethod, '*'];
-        foreach ($methodsToCheck as $method) {
-            if (isset($this->routesByMethod[$method])) {
-                foreach ($this->routesByMethod[$method] as $route) {
-                    if ($route->matchUrl($requestUrl, $this->caseSensitive)) {
-                        $this->executedRoute = $route;
-                        // Set iterator position to this route for potential next() calls
-                        $this->index = array_search($route, $this->routes, true);
-                        return $route;
-                    }
-                }
+        $candidates = ($this->routesByMethod[$requestMethod] ?? []) + ($this->routesByMethod['*'] ?? []);
+        ksort($candidates);
+        foreach ($candidates as $routeIndex => $route) {
+            if ($route->matchUrl($requestUrl, $this->caseSensitive)) {
+                $this->executedRoute = $route;
+                $this->index = $routeIndex;
+                return $route;
             }
         }
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -780,4 +780,21 @@ class RouterTest extends TestCase
         $this->request->method = 'GET';
         $this->check('OK');
     }
+    
+    public function testWildcardPassthroughRouteBeforeSpecificGetRoute(): void
+    {
+        $this->router->map('/@par/[^\/]+/*', function (string $par): bool {
+            echo "Passthrough (Par = $par)";
+            return true;
+        });
+
+        $this->router->map('GET /[^\/]+/target', function (): void {
+            echo ' Target';
+        });
+
+        $this->request->url = '/foobar/target/';
+        $this->request->method = 'GET';
+
+        $this->check('Passthrough (Par = foobar) Target');
+    }
 }


### PR DESCRIPTION
Fixes the route registration order regression introduced in v3.17.1 by the method-specific fast path added in #658.

closes #693

## Fix

Store routes in `routesByMethod` using their **global index** in `$routes` as the array key. When building the fast path candidates, merge the two buckets and `ksort` by key to restore registration order.

```php
// map() — use global route index as key
$this->routesByMethod[$method][count($this->routes) - 1] = $route;

// route() — merge and sort by registration order
$candidates = ($this->routesByMethod[$requestMethod] ?? []) + ($this->routesByMethod['*'] ?? []);
ksort($candidates);
```

Now the merged candidates are always in registration order regardless of method, and the fast path performance benefit (only URL-matching against eligible routes) is preserved.

## Testing

Added regression test `testWildcardPassthroughRouteBeforeSpecificGetRoute` in `RouterTest`.

```
> phpunit --filter RouterTest
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.29
Configuration: C:\FlightPHP\core\phpunit.xml.dist
Random Seed:   1776965395

................................................................. 65 / 66 ( 98%)
.                                                                 66 / 66 (100%)

Time: 00:00.031, Memory: 8.00 MB

OK (66 tests, 87 assertions)
```