### PR TITLE
Throw when middleware class is missing or cannot be resolved

### DIFF
--- a/flight/Engine.php
+++ b/flight/Engine.php
@@ -456,7 +456,22 @@ class Engine
                 $middlewareObject = method_exists($middleware, $eventName) === true ? [$middleware, $eventName] : false;
 
                 // If the middleware is a string, we need to create the object and then call the event.
-            } elseif (is_string($middleware) === true && method_exists($middleware, $eventName) === true) {
+            } elseif (is_string($middleware) === true) {
+                if (class_exists($middleware) === false) {
+                    if (ob_get_level() > (getenv('PHPUNIT_TEST') ? 1 : 0)) {
+                        ob_end_clean();
+                    }
+
+                    throw new Exception(
+                        "Middleware class '$middleware' not found. "
+                            . "Is it being correctly autoloaded with Flight::path()?"
+                    );
+                }
+
+                if (method_exists($middleware, $eventName) === false) {
+                    continue;
+                }
+
                 $resolvedClass = null;
 
                 // if there's a container assigned, we should use it to create the object
@@ -464,14 +479,19 @@ class Engine
                     $resolvedClass = $this->dispatcher->resolveContainerClass($middleware, $params);
                     // otherwise just assume it's a plain jane class, so inject the engine
                     // just like in Dispatcher::invokeCallable()
-                } elseif (class_exists($middleware) === true) {
+                } else {
                     $resolvedClass = new $middleware($this);
                 }
 
-                // If something was resolved, create an array callable that will be passed in later.
-                if ($resolvedClass !== null) {
-                    $middlewareObject = [$resolvedClass, $eventName];
+                if ($resolvedClass === null) {
+                    if (ob_get_level() > (getenv('PHPUNIT_TEST') ? 1 : 0)) {
+                        ob_end_clean();
+                    }
+
+                    throw new Exception("Middleware class '$middleware' could not be resolved.");
                 }
+
+                $middlewareObject = [$resolvedClass, $eventName];
             }
 
             // If nothing was resolved, go to the next thing

--- a/tests/EngineTest.php
+++ b/tests/EngineTest.php
@@ -899,6 +899,40 @@ class EngineTest extends TestCase
         $this->expectOutputString('before456before123OKafter123456after123');
     }
 
+    public function testMiddlewareMissingClassThrowsException(): void
+    {
+        $engine = new Engine();
+        $engine->route('/path1', function () {
+            echo 'OK';
+        })->addMiddleware('TotallyMissingMiddlewareClass');
+
+        $engine->request()->url = '/path1';
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(
+            "Middleware class 'TotallyMissingMiddlewareClass' not found. "
+                . "Is it being correctly autoloaded with Flight::path()?"
+        );
+        $engine->start();
+    }
+
+    public function testMiddlewareMissingClassInGroupThrowsException(): void
+    {
+        $engine = new Engine();
+        $engine->group('', function ($router) {
+            $router->get('/path1', function () {
+                echo 'OK';
+            });
+        }, ['TotallyMissingMiddlewareClass']);
+
+        $engine->request()->url = '/path1';
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(
+            "Middleware class 'TotallyMissingMiddlewareClass' not found. "
+                . "Is it being correctly autoloaded with Flight::path()?"
+        );
+        $engine->start();
+    }
+
     public function testContainerBadClass()
     {
         $engine = new Engine();


### PR DESCRIPTION
## Summary

- Validates string middleware classes at request time instead of silently skipping them
- Throws an exception when a middleware class cannot be autoloaded, matching the error message used for missing route handler classes
- Throws when a middleware class with a container cannot be resolved
- Preserves existing behavior where middleware that only implements `before` or `after` is skipped for the other phase

## Test plan

- [x] Added `testMiddlewareMissingClassThrowsException` for route-level middleware
- [x] Added `testMiddlewareMissingClassInGroupThrowsException` for group middleware
- [x] All 471 existing tests pass

Fixes #696