### PR TITLE
Update homepage URLs in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "flightphp/core",
     "description": "Flight is a fast, simple, extensible framework for PHP. Flight enables you to quickly and easily build RESTful web applications. This is the maintained fork of mikecao/flight",
-    "homepage": "http://flightphp.com",
+    "homepage": "https://docs.flightphp.com",
     "license": "MIT",
     "authors": [
         {
@@ -13,7 +13,7 @@
         {
             "name": "Franyer Sánchez",
             "email": "franyeradriansanchez@gmail.com",
-            "homepage": "https://faslatam.42web.io",
+            "homepage": "https://github.com/fadrian06",
             "role": "Maintainer"
         },
         {


### PR DESCRIPTION
This pull request updates the `composer.json` file with improved and more accurate homepage URLs for both the project and a maintainer.

Project and maintainer metadata updates:

* Updated the project `homepage` field to point to the new documentation site at `https://docs.flightphp.com`.
* Updated maintainer Franyer Sánchez's `homepage` field to their GitHub profile (`https://github.com/fadrian06`) for better attribution and contact.