### PR TITLE
Re-add writable directory check for target path

### DIFF
--- a/flight/net/UploadedFile.php
+++ b/flight/net/UploadedFile.php
@@ -131,14 +131,15 @@ class UploadedFile
             throw new Exception($this->getUploadErrorMessage($this->error));
         }
 
-        if (is_writeable(dirname($targetPath)) === false) {
-            throw new Exception('Target directory is not writable');
-        }
-
         // Prevent path traversal attacks
         if (strpos($targetPath, '..') !== false) {
             throw new Exception('Invalid target path: contains directory traversal');
         }
+
+        if (is_writeable(dirname($targetPath)) === false) {
+            throw new Exception('Target directory is not writable');
+        }
+
         // Prevent absolute paths (basic check for Unix/Windows)
         if ($targetPath[0] === '/' || (strlen($targetPath) > 1 && $targetPath[1] === ':')) {
             throw new Exception('Invalid target path: absolute paths not allowed');


### PR DESCRIPTION
This pull request makes a small but important change to the `moveTo` method in `flight/net/UploadedFile.php`. The check for whether the target directory is writable has been moved to occur after the check for directory traversal in the target path. This helps ensure that path validation is performed before checking permissions, improving security and error handling.

- Security and validation improvements:
  * In `moveTo`, the check for writable target directory now occurs after verifying that the target path does not contain directory traversal sequences, reducing the risk of improper permission checks on unsafe paths.