### PR TITLE
Update workflow to support multiple OS environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,8 @@ jobs:
             fail-fast: false
             matrix:
                 php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
-        runs-on: ubuntu-latest
+                os: [ubuntu-latest, windows-latest, macos-latest]
+        runs-on: ${{ matrix.os }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: curl, mbstring, pdo_sqlite
+                  extensions: curl, mbstring, pdo_sqlite, fileinfo
                   tools: composer:v2
             - run: composer install
             - run: composer test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: curl, mbstring
+                  extensions: curl, mbstring, pdo_sqlite
                   tools: composer:v2
             - run: composer install
             - run: composer test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
-name: Pull Request Check
+name: 🚀 Pull Request Check 🔍
 on: [pull_request]
 
 jobs:
     unit-test:
-        name: Unit testing
+        name: 🧪 Unit Testing - PHP ${{ matrix.php }} on ${{ matrix.os }}
         strategy:
             fail-fast: false
             matrix:
@@ -11,15 +11,17 @@ jobs:
                 os: [ubuntu-latest, windows-latest, macos-latest]
         runs-on: ${{ matrix.os }}
         steps:
-            - name: Checkout repository
+            - name: 📂 Checkout repository
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - uses: shivammathur/setup-php@v2
+            - name: 🐘 Setup PHP ${{ matrix.php }}
+              uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
                   extensions: mbstring, pdo_sqlite, fileinfo
                   tools: composer:v2
-            - run: |
+            - name: 📦 Install dependencies and 🧪 Run tests
+              run: |
                 composer install --no-progress --no-ansi -n
                 composer test -- --colors=never --no-interaction

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
+                php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
                 os: [ubuntu-latest, windows-latest, macos-latest]
         runs-on: ${{ matrix.os }}
         steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,14 @@ jobs:
         runs-on: ${{ matrix.os }}
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: curl, mbstring, pdo_sqlite, fileinfo
+                  extensions: mbstring, pdo_sqlite, fileinfo
                   tools: composer:v2
-            - run: composer install
-            - run: composer test
+            - run: |
+                composer install --no-progress --no-ansi -n
+                composer test -- --colors=never --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,8 @@
         }
     },
     "require-dev": {
+        "ext-mbstring": "*",
+        "ext-fileinfo": "*",
         "ext-pdo_sqlite": "*",
         "flightphp/container": "^1.3",
         "flightphp/runway": "^1.2",

--- a/flight/net/UploadedFile.php
+++ b/flight/net/UploadedFile.php
@@ -131,14 +131,15 @@ class UploadedFile
             throw new Exception($this->getUploadErrorMessage($this->error));
         }
 
-        if (is_writeable(dirname($targetPath)) === false) {
-            throw new Exception('Target directory is not writable');
-        }
-
         // Prevent path traversal attacks
         if (strpos($targetPath, '..') !== false) {
             throw new Exception('Invalid target path: contains directory traversal');
         }
+
+        if (is_writeable(dirname($targetPath)) === false) {
+            throw new Exception('Target directory is not writable');
+        }
+
         // Prevent absolute paths (basic check for Unix/Windows)
         if ($targetPath[0] === '/' || (strlen($targetPath) > 1 && $targetPath[1] === ':')) {
             throw new Exception('Invalid target path: absolute paths not allowed');

--- a/tests/RenderTest.php
+++ b/tests/RenderTest.php
@@ -29,8 +29,12 @@ class RenderTest extends TestCase
     public function testRenderLayout(): void
     {
         $this->app->render('hello', ['name' => 'Bob'], 'content');
+        ob_start();
         $this->app->render('layouts/layout');
+        $html = ob_get_clean();
+        $html = str_replace(["\r\n", "\n"], '', $html);
+        echo $html;
 
-        $this->expectOutputString("<body>Hello, Bob!</body>\n");
+        $this->expectOutputString("<body>Hello, Bob!</body>");
     }
 }

--- a/tests/SimplePdoTest.php
+++ b/tests/SimplePdoTest.php
@@ -171,9 +171,9 @@ class SimplePdoTest extends TestCase
             $this->assertInstanceOf(Collection::class, $row);
             $this->assertSame('Alice', $row['name']);
         } catch (PDOException $exception) {
-            $this->assertSame(
-                'Prepare failed: near "RETURNING": syntax error',
-                $exception->getMessage(),
+            $this->assertStringContainsString(
+                'near "returning": syntax error',
+                strtolower($exception->getMessage()),
             );
         }
     }

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -114,6 +114,10 @@ class UploadedFileTest extends TestCase
 
     public function testMoveToSymlinkNonPost(): void
     {
+        if (PHP_OS === 'WINNT') {
+            $this->markTestSkipped('Symbolic links require special privileges on Windows.');
+        }
+
         file_put_contents('real_file', 'test');
         if (file_exists('tmp_symlink')) {
             unlink('tmp_symlink');

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -102,9 +102,13 @@ class ViewTest extends TestCase
         $this->view->set('name', 'Bob');
         $this->view->extension = '.html';
 
+        ob_start();
         $this->view->render('world');
+        $html = ob_get_clean();
+        $html = str_replace(["\r\n", "\n"], '', $html);
+        echo $html;
 
-        $this->expectOutputString("Hello world, Bob!\n");
+        $this->expectOutputString("Hello world, Bob!");
     }
 
     public function testGetTemplateAbsolutePath(): void

--- a/tests/commands/RouteCommandTest.php
+++ b/tests/commands/RouteCommandTest.php
@@ -123,8 +123,8 @@ PHP;
         output; // phpcs:ignore
 
         $this->assertStringContainsString(
-            str_replace(PHP_EOL, '', $expected),
-            str_replace(PHP_EOL, '', $this->removeColors(file_get_contents(static::$ou))),
+            str_replace(["\r\n", "\n"], '', $expected),
+            str_replace(["\r\n", "\n"], '', $this->removeColors(file_get_contents(static::$ou))),
         );
     }
 


### PR DESCRIPTION
This pull request updates the test workflow configuration to expand the operating systems used in the test matrix. Now, tests will run on Ubuntu, Windows, and macOS environments for each PHP version.

Test matrix improvements:

* Added an `os` matrix to the workflow, so tests are now run on `ubuntu-latest`, `windows-latest`, and `macos-latest` for each PHP version. Updated the `runs-on` field to use the matrix value. (.github/workflows/test.yml)