### PR TITLE
Simplify code coverage generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,6 @@
             "phpunit-watcher watch"
         ],
         "test-coverage": [
-            "rm -f clover.xml",
             "@putenv XDEBUG_MODE=coverage",
             "phpunit --coverage-html=coverage --coverage-clover=clover.xml",
             "coverage-check clover.xml 100"
@@ -84,11 +83,6 @@
         "test-server-v2": [
             "echo \"Running Test Server\"",
             "@php -S localhost:8000 -t tests/server-v2"
-        ],
-        "test-coverage:win": [
-            "del clover.xml",
-            "phpunit --coverage-html=coverage --coverage-clover=clover.xml",
-            "coverage-check clover.xml 100"
         ],
         "test-performance": [
             "echo \"Running Performance Tests...\"",


### PR DESCRIPTION
This pull request makes minor updates to the `composer.json` scripts related to test coverage. The main change is the removal of redundant commands for deleting the `clover.xml` coverage file before running tests, as well as the removal of the Windows-specific `test-coverage:win` script.

Test coverage script cleanup:

* Removed the command to delete `clover.xml` before running the `test-coverage` script, simplifying the process for all environments.
* Removed the `test-coverage:win` script, which included Windows-specific commands for deleting `clover.xml` and running coverage checks, consolidating coverage testing into a single script.