### PR TITLE
Combine PHPStan and PHPCS in lint script

### DIFF
--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -15,9 +15,8 @@ This is the main FlightPHP core library for building fast, simple, and extensibl
 ## Development & Testing
 - Run tests: `composer test` (uses phpunit/phpunit and spatie/phpunit-watcher)
 - Run test server: `composer test-server` or `composer test-server-v2`
-- Lint code: `composer lint` (uses phpstan/phpstan, level 6)
+- Lint code & Check code style: `composer lint` (uses phpstan/phpstan, level 6)
 - Beautify code: `composer beautify` (uses squizlabs/php_codesniffer, PSR1)
-- Check code style: `composer phpcs`
 - Test coverage: `composer test-coverage`
 
 ## Coding Standards

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,9 +15,8 @@ This is the main FlightPHP core library for building fast, simple, and extensibl
 ## Development & Testing
 - Run tests: `composer test` (uses phpunit/phpunit and spatie/phpunit-watcher)
 - Run test server: `composer test-server` or `composer test-server-v2`
-- Lint code: `composer lint` (uses phpstan/phpstan, level 6)
+- Lint code & Check code style: `composer lint` (uses phpstan/phpstan, level 6)
 - Beautify code: `composer beautify` (uses squizlabs/php_codesniffer, PSR1)
-- Check code style: `composer phpcs`
 - Test coverage: `composer test-coverage`
 
 ## Coding Standards

--- a/composer.json
+++ b/composer.json
@@ -99,9 +99,11 @@
             "rm server.pid",
             "echo \"Performance Tests Completed.\""
         ],
-        "lint": "phpstan --no-progress --memory-limit=256M",
+        "lint": [
+            "phpstan --no-progress --memory-limit=256M -n",
+            "phpcs"
+        ],
         "beautify": "phpcbf",
-        "phpcs": "phpcs",
         "post-install-cmd": [
             "@php -r \"if (!file_exists('phpcs.xml')) copy('phpcs.xml.dist', 'phpcs.xml');\"",
             "@php -r \"if (!file_exists('phpstan.neon')) copy('phpstan.dist.neon', 'phpstan.neon');\"",


### PR DESCRIPTION
This pull request updates the Composer `lint` script to run both static analysis and code style checks, streamlining the code quality process.

**Build and code quality tooling:**

* Updated the `lint` script in `composer.json` to run both `phpstan` (with the `-n` flag for no interaction) and `phpcs`, ensuring that both static analysis and code style checks are performed together.