### PR TITLE
Add phpunit-watcher for improved testing and customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ phpunit.xml
 .runway-config.json
 .runway-creds.json
 .DS_Store
+.phpunit-watcher.yml

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^9.6",
         "rregeer/phpunit-coverage-check": "^0.3.1",
+        "spatie/phpunit-watcher": "^1.23",
         "squizlabs/php_codesniffer": "^4.0"
     },
     "config": {
@@ -67,10 +68,7 @@
     },
     "scripts": {
         "test": "phpunit",
-        "test-watcher": [
-            "phpunit-watcher || composer global require spatie/phpunit-watcher --dev",
-            "phpunit-watcher watch"
-        ],
+        "test-watcher": "phpunit-watcher watch",
         "test-coverage": [
             "rm -f clover.xml",
             "@putenv XDEBUG_MODE=coverage",

--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,8 @@
         "post-install-cmd": [
             "@php -r \"if (!file_exists('phpcs.xml')) copy('phpcs.xml.dist', 'phpcs.xml');\"",
             "@php -r \"if (!file_exists('phpstan.neon')) copy('phpstan.dist.neon', 'phpstan.neon');\"",
-            "@php -r \"if (!file_exists('phpunit.xml')) copy('phpunit.xml.dist', 'phpunit.xml');\""
+            "@php -r \"if (!file_exists('phpunit.xml')) copy('phpunit.xml.dist', 'phpunit.xml');\"",
+            "@php -r \"if (!file_exists('.phpunit-watcher.yml')) copy('phpunit-watcher.yml', '.phpunit-watcher.yml');\""
         ]
     },
     "suggest": {

--- a/phpunit-watcher.yml
+++ b/phpunit-watcher.yml
@@ -1,13 +1,13 @@
 hideManual: true
+notifications:
+  failingTests: false
+  passingTests: false
+phpunit:
+  arguments: '--stop-on-failure'
+  binaryPath: ./vendor/bin/phpunit
+  timeout: 180
 watch:
   directories:
     - tests
     - flight
   fileMask: '*.php'
-notifications:
-  passingTests: false
-  failingTests: false
-phpunit:
-  binaryPath: ./vendor/bin/phpunit
-  arguments: '--stop-on-failure'
-  timeout: 180


### PR DESCRIPTION
This pull request updates the project's test-watching setup to improve reliability and configuration consistency. The main changes involve ensuring the `spatie/phpunit-watcher` dependency is managed directly by Composer, simplifying the test watcher script, and reordering settings in the `phpunit-watcher.yml` file for clarity.

**Dependency management:**
* Added `spatie/phpunit-watcher` as a development dependency in `composer.json` to ensure it is always available and versioned with the project.

**Test script simplification:**
* Updated the `test-watcher` script in `composer.json` to directly run `phpunit-watcher watch`, removing the previous logic that attempted to install it globally if missing.

**Configuration cleanup:**
* Reordered and regrouped sections in `phpunit-watcher.yml` for consistency, moving the `watch` section to the end and ensuring notification and PHPUnit settings are clearly organized. No functional changes, but improves readability and maintainability.