### PR TITLE
Rename beautify command to format

### DIFF
--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -16,7 +16,7 @@ This is the main FlightPHP core library for building fast, simple, and extensibl
 - Run tests: `composer test` (uses phpunit/phpunit and spatie/phpunit-watcher)
 - Run test server: `composer test-server` or `composer test-server-v2`
 - Lint code: `composer lint` (uses phpstan/phpstan, level 6)
-- Beautify code: `composer beautify` (uses squizlabs/php_codesniffer, PSR1)
+- Format code: `composer format` (uses squizlabs/php_codesniffer, PSR1)
 - Check code style: `composer phpcs`
 - Test coverage: `composer test-coverage`
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@ This is the main FlightPHP core library for building fast, simple, and extensibl
 - Run tests: `composer test` (uses phpunit/phpunit and spatie/phpunit-watcher)
 - Run test server: `composer test-server` or `composer test-server-v2`
 - Lint code: `composer lint` (uses phpstan/phpstan, level 6)
-- Beautify code: `composer beautify` (uses squizlabs/php_codesniffer, PSR1)
+- Format code: `composer format` (uses squizlabs/php_codesniffer, PSR1)
 - Check code style: `composer phpcs`
 - Test coverage: `composer test-coverage`
 

--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
             "echo \"Performance Tests Completed.\""
         ],
         "lint": "phpstan --no-progress --memory-limit=256M",
-        "beautify": "phpcbf",
+        "format": "phpcbf -q",
         "phpcs": "phpcs",
         "post-install-cmd": [
             "@php -r \"if (!file_exists('phpcs.xml')) copy('phpcs.xml.dist', 'phpcs.xml');\"",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,26 +2,10 @@
 <ruleset
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
-    <!-- <arg name="report" value="source" /> -->
-    <!-- <arg name="report" value="summary" /> -->
-    <!-- <arg name="report" value="diff" /> -->
-    <arg name="report" value="full" />
-    <arg name="report-width" value="80" />
     <arg name="colors" />
-    <arg name="encoding" value="utf-8" />
-    <arg name="tab-width" value="4" />
-
-    <rule ref="PSR1">
-    </rule>
-
-    <rule ref="PSR2">
-    </rule>
-
-    <rule ref="PSR12">
-        <exclude name="PSR12.Classes.AnonClassDeclaration.SpaceAfterKeyword"/>
-    </rule>
-
-    <file>index.php</file>
     <file>flight</file>
     <file>tests</file>
+    <rule ref="PSR1" />
+    <rule ref="PSR2" />
+    <rule ref="PSR12" />
 </ruleset>

--- a/tests/SimplePdoTest.php
+++ b/tests/SimplePdoTest.php
@@ -88,7 +88,7 @@ class SimplePdoTest extends TestCase
 
     public function testRunQueryWithoutParamsWithMaxQueryMetrics(): void
     {
-        $db = new class(
+        $db = new class (
             'sqlite::memory:',
             null,
             null,

--- a/tests/named-arguments/FlightTest.php
+++ b/tests/named-arguments/FlightTest.php
@@ -75,7 +75,7 @@ final class FlightTest extends TestCase
     {
         $dateTime = new DateTimeImmutable();
 
-        $controller = new class($dateTime) {
+        $controller = new class ($dateTime) {
             public function __construct(private DateTimeImmutable $dateTime)
             {
                 //


### PR DESCRIPTION
This pull request updates the project's PHP code formatting and linting configuration, focusing on simplifying and standardizing the code style tools and their settings.

**Code formatting and linting configuration:**

* Renamed the Composer script from `beautify` to `format` and updated it to run `phpcbf` in quiet mode for automatic code formatting.
* Cleaned up the `phpcs.xml.dist` configuration by removing commented-out and redundant arguments, streamlining the rule definitions for PSR1, PSR2, and PSR12, and restricting code checks to the `flight` and `tests` directories.