### PR TITLE
feat(ai): generate AGENTS.md in ai:generate-instructions command

### DIFF
--- a/flight/commands/AiGenerateInstructionsCommand.php
+++ b/flight/commands/AiGenerateInstructionsCommand.php
@@ -167,7 +167,7 @@ class AiGenerateInstructionsCommand extends AbstractBaseCommand
         $io->info(
             'Updating .github/copilot-instructions.md, '
                 . '.cursor/rules/project-overview.mdc, '
-                . '.gemini/GEMINI.md and .windsurfrules...',
+                . '.gemini/GEMINI.md, .windsurfrules and AGENTS.md...',
             true
         );
 
@@ -184,6 +184,7 @@ class AiGenerateInstructionsCommand extends AbstractBaseCommand
         file_put_contents($this->projectRoot . '.cursor/rules/project-overview.mdc', $instructions);
         file_put_contents($this->projectRoot . '.gemini/GEMINI.md', $instructions);
         file_put_contents($this->projectRoot . '.windsurfrules', $instructions);
+        file_put_contents($this->projectRoot . 'AGENTS.md', $instructions);
         $io->ok('AI instructions updated successfully.', true);
         return 0;
     }

--- a/tests/commands/AiGenerateInstructionsCommandTest.php
+++ b/tests/commands/AiGenerateInstructionsCommandTest.php
@@ -167,6 +167,7 @@ class AiGenerateInstructionsCommandTest extends TestCase
         $this->assertFileExists($this->baseDir . '.cursor/rules/project-overview.mdc');
         $this->assertFileExists($this->baseDir . '.gemini/GEMINI.md');
         $this->assertFileExists($this->baseDir . '.windsurfrules');
+        $this->assertFileExists($this->baseDir . 'AGENTS.md');
     }
 
     public function testNoInstructionsReturnedFromLlm()


### PR DESCRIPTION
## Summary

- Updates `ai:generate-instructions` to also write generated AI instructions to `AGENTS.md` at the project root
- Keeps output in sync with the existing `.github/copilot-instructions.md`, `.cursor/rules/project-overview.mdc`, `.gemini/GEMINI.md`, and `.windsurfrules` files
- Adds a test assertion that `AGENTS.md` is created

## Test plan

- [x] `./vendor/bin/phpunit tests/commands/AiGenerateInstructionsCommandTest.php`