### PR TITLE
Use static callables with type hints

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/flight/autoload.php';
 
-Flight::route('/', function () {
+Flight::route('/', static function (): void {
     echo 'hello world!';
 });
 


### PR DESCRIPTION
This pull request makes a small change to the root route definition in `index.php`, updating the route handler to use a static anonymous function for improved performance and clarity.